### PR TITLE
Use the project.version variable, instead of another variable in pom.xml

### DIFF
--- a/build/assembly.xml
+++ b/build/assembly.xml
@@ -14,7 +14,7 @@ http://maven.apache.org/plugins/maven-assembly-plugin/assembly.html
         <fileSet>
             <directory>target</directory>
             <includes>
-                <include>Cantaloupe-${cantaloupe.version}.war</include>
+                <include>Cantaloupe-${project.version}.war</include>
             </includes>
             <outputDirectory>.</outputDirectory>
         </fileSet>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,6 @@
   <groupId>edu.illinois.library.cantaloupe</groupId>
   <artifactId>Cantaloupe</artifactId>
   <packaging>war</packaging>
-  <!-- needs to be kept synchronized with properties/cantaloupe.version -->
   <version>3.3-SNAPSHOT</version>
   <name>Cantaloupe</name>
   <url>https://medusa-project.github.io/cantaloupe/</url>
@@ -14,7 +13,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <cantaloupe.version>3.3-SNAPSHOT</cantaloupe.version>
     <restlet.version>2.3.7</restlet.version>
   </properties>
 


### PR DESCRIPTION
The [project.version variable](https://maven.apache.org/guides/introduction/introduction-to-the-pom.html#Project_Interpolation_and_Variables) can be used to retrieve the current version in pom.xml.

With that, it won't be necessary to keep both cantaloupe.version and the pom.xml version in sync, preventing issues, and simplifying the build pipeline.

Tested locally, get the Cantaloupe-3.3-SNAPSHOT.zip in my target folder, just as before the change.

Bruno