### PR TITLE
Fix link to deployment section with Nginx

### DIFF
--- a/website/manual/3.3/deployment.html
+++ b/website/manual/3.3/deployment.html
@@ -131,7 +131,7 @@ title: Deployment
 &lt;/VirtualHost&gt;
 </pre>
 
-<h3 id="ReverseProxyingNginx">nginx</h3>
+<h3 id="Reverse-ProxyingNginx">nginx</h3>
 
 <p>The following example will make a Cantaloupe server running at http://image-server:8182/ available at http://nginx-server/.
 


### PR DESCRIPTION
The link to the section reverse proxying with Nginx is broken in the table of contents.