### PR TITLE
Add usage method, and print the usage when no config was provided, instead of throwing NullPointerException

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/StandaloneEntry.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/StandaloneEntry.java
@@ -36,27 +36,27 @@ public class StandaloneEntry {
     public static void main(String[] args) throws Exception {
         final Configuration config = ConfigurationFactory.getInstance();
         if (config == null) {
-            usage();
+            printUsage();
             System.exit(-1);
         }
         final File configFile = config.getFile();
         if (configFile == null) {
-            usage();
+            printUsage();
             System.exit(-1);
         }
         if (!configFile.exists()) {
             System.out.println("Does not exist: " + configFile);
-            usage();
+            printUsage();
             System.exit(-1);
         }
         if (!configFile.isFile()) {
             System.out.println("Not a file: " + configFile);
-            usage();
+            printUsage();
             System.exit(-1);
         }
         if (!configFile.canRead()) {
             System.out.println("Not readable: " + configFile);
-            usage();
+            printUsage();
             System.exit(-1);
         }
         getWebServer().start();
@@ -65,7 +65,7 @@ public class StandaloneEntry {
     /**
      * Print program usage.
      */
-    private static void usage() {
+    private static void printUsage() {
         System.out.println("Usage: java " +
                 "-D" + ConfigurationFactory.CONFIG_VM_ARGUMENT +
                 "=cantaloupe.properties -jar " + getWarFile().getName());

--- a/src/main/java/edu/illinois/library/cantaloupe/StandaloneEntry.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/StandaloneEntry.java
@@ -35,26 +35,40 @@ public class StandaloneEntry {
      */
     public static void main(String[] args) throws Exception {
         final Configuration config = ConfigurationFactory.getInstance();
+        if (config == null) {
+            usage();
+            System.exit(-1);
+        }
         final File configFile = config.getFile();
         if (configFile == null) {
-            System.out.println("Usage: java " +
-                    "-D" + ConfigurationFactory.CONFIG_VM_ARGUMENT +
-                    "=cantaloupe.properties -jar " + getWarFile().getName());
+            usage();
             System.exit(-1);
         }
         if (!configFile.exists()) {
             System.out.println("Does not exist: " + configFile);
+            usage();
             System.exit(-1);
         }
         if (!configFile.isFile()) {
             System.out.println("Not a file: " + configFile);
+            usage();
             System.exit(-1);
         }
         if (!configFile.canRead()) {
             System.out.println("Not readable: " + configFile);
+            usage();
             System.exit(-1);
         }
         getWebServer().start();
+    }
+
+    /**
+     * Print program usage.
+     */
+    private static void usage() {
+        System.out.println("Usage: java " +
+                "-D" + ConfigurationFactory.CONFIG_VM_ARGUMENT +
+                "=cantaloupe.properties -jar " + getWarFile().getName());
     }
 
     static File getWarFile() {


### PR DESCRIPTION
The first time I started the application in my Eclipse workspace I got a NPE, and didn't understand if I was doing some mistake, or if there was a bug in the develop branch.

The output also didn't include the usage, but after reading the code I noticed that I had to provide a configuration file (I should have read the manual actually, I know :-) ).

This pull request adds a usage method, and checks if the configuration object was not created, and if so, prints the usage and exists.

It also prints the usage for the other cases like when there is no file, or instead of a file the user provided a directory.