### PR TITLE
Docker deploy

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,55 @@
+FROM openjdk:8-jdk-alpine
+
+# Cantaloupe docker starter script
+# For pyramidal tiffs using JAI processor and filesystem resolver and -cache
+
+# Build and run: 
+# $ sudo docker build -t cantaloupe .
+# $ sudo docker run -d --rm -p 8183:8182 -v /Users/kjauslin/dev/projects/nbvv-testing/images:/var/lib/cantaloupe/images --name cantaloupe cantaloupe
+
+ENV CANTALOUPE_VERSION 3.2.2
+EXPOSE 8182
+
+RUN apk add --update -X http://dl-cdn.alpinelinux.org/alpine/edge/community \
+    curl \
+    graphicsmagick
+
+# run non priviledged
+#RUN groupadd -r www-data && useradd -r -g www-data cantaloupe
+RUN adduser -S cantaloupe
+
+#
+# Cantaloupe
+#
+WORKDIR /tmp
+RUN curl -OL https://github.com/medusa-project/cantaloupe/releases/download/v$CANTALOUPE_VERSION/Cantaloupe-$CANTALOUPE_VERSION.zip \
+ && mkdir -p /usr/local/ \
+ && cd /usr/local \
+ && unzip /tmp/Cantaloupe-$CANTALOUPE_VERSION.zip \
+ && ln -s Cantaloupe-$CANTALOUPE_VERSION cantaloupe \
+ && rm -rf /tmp/Cantaloupe-$CANTALOUPE_VERSION \
+ && rm /tmp/Cantaloupe-$CANTALOUPE_VERSION.zip
+
+# upcoming docker releases: use --chown=cantaloupe
+COPY cantaloupe.properties /etc/cantaloupe.properties 
+RUN mkdir -p /var/log/cantaloupe \
+ && mkdir -p /var/cache/cantaloupe \
+ && chown -R cantaloupe /var/log/cantaloupe \
+ && chown -R cantaloupe /var/cache/cantaloupe \
+ && chown cantaloupe /etc/cantaloupe.properties
+
+#
+# JAI (not functional yet)
+#
+# ENV JAI_PKG jai-1_1_3-lib-linux-amd64
+# RUN curl -OL http://download.java.net/media/jai/builds/release/1_1_3/$JAI_PKG.tar.gz \
+#  && tar xvfz /tmp/$JAI_PKG.tar.gz \
+#  && cp jai-1_1_3/lib/*.jar $JAVA_HOME/jre/lib/ext/ \
+#  && cp jai-1_1_3/lib/*.so $JAVA_HOME/jre/lib/amd64/ \
+#  && rm $JAI_PKG.tar.gz \
+#  && rm -rf jai-1_1_3
+
+USER cantaloupe 
+#VOLUME ["/var/lib/cantaloupe/images", "/var/log/cantaloupe", "/var/cache/cantaloupe"]
+CMD ["sh", "-c", "java -Dcantaloupe.config=/etc/cantaloupe.properties -Xmx2g -jar /usr/local/cantaloupe/Cantaloupe-$CANTALOUPE_VERSION.war"]
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ FROM openjdk:8-jdk-alpine
 
 # Build and run: 
 # $ sudo docker build -t cantaloupe .
-# $ sudo docker run -d --rm -p 8183:8182 -v /Users/kjauslin/dev/projects/nbvv-testing/images:/var/lib/cantaloupe/images --name cantaloupe cantaloupe
+# $ sudo docker run -d --rm -p 8183:8182 -v ./images:/var/lib/cantaloupe/images --name cantaloupe cantaloupe
 
 ENV CANTALOUPE_VERSION 3.2.2
 EXPOSE 8182
@@ -39,7 +39,7 @@ RUN mkdir -p /var/log/cantaloupe \
  && chown cantaloupe /etc/cantaloupe.properties
 
 #
-# JAI (not functional yet)
+# JAI native medialib (non functional)
 #
 # ENV JAI_PKG jai-1_1_3-lib-linux-amd64
 # RUN curl -OL http://download.java.net/media/jai/builds/release/1_1_3/$JAI_PKG.tar.gz \

--- a/docker/cantaloupe.properties
+++ b/docker/cantaloupe.properties
@@ -1,0 +1,648 @@
+###########################################################################
+# Sample Cantaloupe configuration file
+#
+# Copy this file to `cantaloupe.properties` and edit as desired.
+#
+# Most changes will take effect without restarting. Those that won't are
+# marked with "!!".
+###########################################################################
+
+# !! Whether to enable HTTP access (http://), and on what host interface
+# and TCP port. (Applies in standalone mode only.)
+http.enabled = true
+http.host = 0.0.0.0
+http.port = 8182
+
+# !! Whether to enable HTTPS access (https://), and on what host interface
+# and TCP port. (Applies in standalone mode only.)
+https.enabled = false
+https.host = 0.0.0.0
+https.port = 8183
+
+# !! Available values are `JKS` and `PKCS12`. (Standalone mode only.)
+https.key_store_type = JKS
+https.key_store_password = myPassword
+https.key_store_path = /path/to/keystore.jks
+https.key_password = myPassword
+
+# !! Configures HTTP Basic authentication.
+auth.basic.enabled = false
+auth.basic.username = myself
+auth.basic.secret = mypassword
+
+# Enables the Control Panel, at /admin.
+admin.enabled = true
+# Password to access the Control Panel. (The username is "admin".)
+admin.password = docker
+
+# Base URI to use for internal links, such as Link headers and JSON-LD @id
+# values, in a reverse-proxy context. This should only be used when
+# X-Forwarded-* headers cannot be used instead (see the user manual).
+base_uri =
+
+# Normally, slashes in a URI path component must be percent-encoded as
+# "%2F". If your proxy is incapable of passing these through without
+# decoding them, you can define an alternate character or character
+# sequence to substitute for a slash. Supply the non-percent-encoded
+# version here, and use the percent-encoded version in URLs.
+slash_substitute =
+
+# Maximum number of pixels to return in a response, to prevent overloading
+# the server. Requests for more pixels than this will receive an error
+# response. Set to 0 for no maximum.
+max_pixels = 400000000
+
+# Sometimes helpful.
+print_stack_trace_on_error_pages = true
+
+###########################################################################
+# DELEGATE SCRIPT
+###########################################################################
+
+# !! Enables the delegate script: a Ruby script containing various delegate
+# methods. (See the user manual.)
+delegate_script.enabled = false
+
+# !! This can be an absolute path, or a filename; if only a
+# filename is specified, it will be searched for in the same folder as this
+# file, and then the current working directory.
+delegate_script.pathname = delegates.rb
+
+# Enables the invocation cache, which caches method invocations and
+# return values in memory. See the user manual for more information.
+delegate_script.cache.enabled = false
+
+# !! Maximum size of the invocation cache. This is pretty much a wild
+# guess.
+delegate_script.cache.max_size = 1000000
+
+###########################################################################
+# ENDPOINTS
+###########################################################################
+
+endpoint.iiif.1.enabled = true
+
+endpoint.iiif.2.enabled = true
+
+# Controls the response Content-Disposition header for images. Allowed
+# values are `inline`, `attachment`, and `none`.
+endpoint.iiif.content_disposition = inline
+
+# Minimum size that will be used in info.json "tiles" keys. See the user
+# manual for an explanation of how these are calculated.
+endpoint.iiif.min_tile_size = 1024
+
+# If true, requests for sizes other than those specified in an info.json
+# response will be denied.
+endpoint.iiif.2.restrict_to_sizes = false
+
+# Enables the administrative REST API. (See the user manual.)
+endpoint.api.enabled = false
+
+# HTTP Basic credentials to access the REST API.
+endpoint.api.username =
+endpoint.api.secret =
+
+###########################################################################
+# RESOLVERS
+###########################################################################
+
+# Specifies one resolver to translate the identifier in the URL to an image
+# source for all requests. Available values are `FilesystemResolver`,
+# `HttpResolver`, `JdbcResolver`, `AmazonS3Resolver`, and
+# `AzureStorageResolver`.
+resolver.static = FilesystemResolver
+
+# If true, `resolver.static` will be overridden, and the
+# `get_resolver(identifier)` delegate script method will be used to select
+# a resolver per-request.
+resolver.delegate = false
+
+#----------------------------------------
+# FilesystemResolver
+#----------------------------------------
+
+# Tells FilesystemResolver how to look up files. Allowed values are
+# `BasicLookupStrategy` and `ScriptLookupStrategy`. ScriptLookupStrategy
+# uses the delegate script for dynamic lookups; see the user manual for
+# details.
+FilesystemResolver.lookup_strategy = BasicLookupStrategy
+
+# Server-side path that will be prefixed to the identifier in the URL.
+# Trailing slash is important.
+FilesystemResolver.BasicLookupStrategy.path_prefix = /var/lib/cantaloupe/images/
+
+# Server-side path or extension that will be suffixed to the identifier in
+# the URL.
+FilesystemResolver.BasicLookupStrategy.path_suffix =
+
+#----------------------------------------
+# HttpResolver
+#----------------------------------------
+
+# Tells HttpResolver how to look up resources. Allowed values are
+# `BasicLookupStrategy` and `ScriptLookupStrategy`. ScriptLookupStrategy
+# uses the delegate script for dynamic lookups; see the user manual for
+# details.
+HttpResolver.lookup_strategy = BasicLookupStrategy
+
+# URL that will be prefixed to the identifier in the request URL. Trailing
+# slash is important.
+HttpResolver.BasicLookupStrategy.url_prefix = http://localhost/images/
+
+# Path, extension, query string, etc. that will be suffixed to the
+# identifier in the request URL.
+HttpResolver.BasicLookupStrategy.url_suffix =
+
+# Used for HTTP Basic authentication.
+HttpResolver.auth.basic.username =
+HttpResolver.auth.basic.secret =
+
+#----------------------------------------
+# JdbcResolver
+#----------------------------------------
+
+# Note: JdbcResolver requires some delegate methods to be implemented in
+# addition to the configuration here; see the user manual.
+
+# !!
+JdbcResolver.url = jdbc:postgresql://localhost:5432/my_database
+# !!
+JdbcResolver.user = postgres
+# !!
+JdbcResolver.password = postgres
+
+# !! Connection timeout in seconds.
+JdbcResolver.connection_timeout = 10
+
+#----------------------------------------
+# AmazonS3Resolver
+#----------------------------------------
+
+# !! Access key ID and secret key associated with your AWS account.
+# See: http://aws.amazon.com/security-credentials
+AmazonS3Resolver.access_key_id =
+AmazonS3Resolver.secret_key =
+
+# !! Name of the bucket containing images to be served.
+AmazonS3Resolver.bucket.name =
+
+# !! Can be left blank.
+# See: http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+AmazonS3Resolver.bucket.region =
+
+# Tells AmazonS3Resolver how to look up objects. Allowed values are
+# `BasicLookupStrategy` and `ScriptLookupStrategy`. ScriptLookupStrategy
+# uses the delegate script for dynamic lookups; see the user manual for
+# details.
+AmazonS3Resolver.lookup_strategy = BasicLookupStrategy
+
+#----------------------------------------
+# AzureStorageResolver
+#----------------------------------------
+
+# !! Name of your Azure account.
+AzureStorageResolver.account_name =
+
+# !! Key of your Azure account.
+AzureStorageResolver.account_key =
+
+# !! Name of the container containing images to be served.
+AzureStorageResolver.container_name =
+
+# Tells AzureStorageResolver how to look up objects. Allowed values are
+# `BasicLookupStrategy` and `ScriptLookupStrategy`. ScriptLookupStrategy
+# uses the delegate script for dynamic lookups; see the user manual for
+# details.
+AzureStorageResolver.lookup_strategy = BasicLookupStrategy
+
+###########################################################################
+# PROCESSORS
+###########################################################################
+
+# Image processors to use for various source formats. Available values are
+# `Java2dProcessor`, `GraphicsMagickProcessor`, `ImageMagickProcessor`,
+# `KakaduProcessor`, `OpenJpegProcessor`, `JaiProcessor`, `PdfBoxProcessor`,
+# and `FfmpegProcessor`.
+
+# These extension-specific definitions are optional.
+processor.avi = FfmpegProcessor
+processor.bmp =
+processor.gif =
+processor.jp2 = KakaduProcessor
+processor.jpg =
+processor.mov = FfmpegProcessor
+processor.mp4 = FfmpegProcessor
+processor.mpg = FfmpegProcessor
+processor.pdf = PdfBoxProcessor
+processor.png =
+processor.tif = Java2dProcessor
+processor.webm = FfmpegProcessor
+processor.webp = ImageMagickProcessor
+
+# Fall back to this processor for any formats not assigned above.
+processor.fallback = Java2dProcessor
+
+# Available values are `StreamStrategy` and `CacheStrategy`. StreamStrategy
+# will try to stream source images from non-filesystem resolvers, when this
+# is possible; CacheStrategy will first download them into the source cache
+# using FilesystemCache, which must also be configured.
+StreamProcessor.retrieval_strategy = StreamStrategy
+
+#----------------------------------------
+# FfmpegProcessor
+#----------------------------------------
+
+# Optional absolute path of the directory containing the FFmpeg binaries.
+# Overrides the PATH.
+FfmpegProcessor.path_to_binaries =
+
+# See Java2dProcessor.upscale_filter for a list of available filters.
+FfmpegProcessor.upscale_filter = bicubic
+FfmpegProcessor.downscale_filter = bicubic
+
+# Intensity of an unsharp mask from 0 to 1.
+FfmpegProcessor.sharpen = 0
+
+#----------------------------------------
+# GraphicsMagickProcessor
+#----------------------------------------
+
+# !! Optional absolute path of the directory containing the GraphicsMagick
+# binary. Overrides the PATH.
+GraphicsMagickProcessor.path_to_binaries =
+
+# Color of the background when an image is rotated. Only affects output
+# formats that do not support transparency.
+GraphicsMagickProcessor.background_color = black
+
+# Adjusts levels to utilize available dynamic range.
+GraphicsMagickProcessor.normalize = false
+
+# Intensity of an unsharp mask from 0 to 1.
+GraphicsMagickProcessor.sharpen = 0
+
+#----------------------------------------
+# ImageMagickProcessor
+#----------------------------------------
+
+# !! Optional absolute path of the directory containing the ImageMagick
+# binaries. Overrides the PATH.
+ImageMagickProcessor.path_to_binaries = /usr/local/bin
+
+# Color of the background when an image is rotated. Only affects output
+# formats that do not support transparency.
+ImageMagickProcessor.background_color = black
+
+# Expands contrast to utilize available dynamic range.
+ImageMagickProcessor.normalize = false
+
+# Intensity of an unsharp mask from 0 to 1.
+ImageMagickProcessor.sharpen = 0
+
+#----------------------------------------
+# JaiProcessor
+#----------------------------------------
+
+# Expands contrast to utilize available dynamic range. This forces the entire
+# source image to be read into memory, so can be slow with large images.
+JaiProcessor.normalize = false
+
+# Intensity of an unsharp mask from 0 to 1.
+JaiProcessor.sharpen = 0
+
+# JPEG output quality. Should be a number between 0-1.
+JaiProcessor.jpg.quality = 0.8
+
+# TIFF output compression type. Available values are `LZW`, `Deflate`,
+# `ZLib`, `JPEG`, and `PackBits`. Leave blank for no compression.
+JaiProcessor.tif.compression = LZW
+
+#----------------------------------------
+# Java2dProcessor
+#----------------------------------------
+
+# Available values are `bell`, `bspline`, `bicubic`, `box`, `hermite`,
+# `lanczos3`, `mitchell`, `triangle`.
+Java2dProcessor.upscale_filter = bicubic
+Java2dProcessor.downscale_filter = bicubic
+
+# Expands contrast to utilize available dynamic range. This forces the entire
+# source image to be read into memory, so can be slow with large images.
+Java2dProcessor.normalize = false
+
+# Intensity of an unsharp mask from 0 to 1.
+Java2dProcessor.sharpen = 0
+
+# JPEG output quality. Should be a number between 0-1.
+Java2dProcessor.jpg.quality = 0.8
+
+# TIFF output compression type. Available values are `LZW`, `Deflate`,
+# `ZLib`, `JPEG`, and `PackBits`. Leave blank for no compression.
+Java2dProcessor.tif.compression = LZW
+
+#----------------------------------------
+# KakaduProcessor
+#----------------------------------------
+
+# Optional absolute path of the directory containing the Kakadu binaries.
+# Overrides the PATH.
+KakaduProcessor.path_to_binaries =
+
+# Expands contrast to utilize available dynamic range. This forces the entire
+# image area to be read into memory.
+KakaduProcessor.normalize = false
+
+# See Java2dProcessor.upscale_filter for a list of available filters.
+KakaduProcessor.upscale_filter = bicubic
+KakaduProcessor.downscale_filter = bicubic
+
+# Intensity of an unsharp mask from 0 to 1.
+KakaduProcessor.sharpen = 0
+
+#----------------------------------------
+# OpenJpegProcessor
+#----------------------------------------
+
+# Optional absolute path of the directory containing the OpenJPEG binaries.
+# Overrides the PATH.
+OpenJpegProcessor.path_to_binaries =
+
+# Expands contrast to utilize available dynamic range. This forces the entire
+# image area to be read into memory.
+OpenJpegProcessor.normalize = false
+
+# See Java2dProcessor.upscale_filter for a list of available filters.
+OpenJpegProcessor.upscale_filter = bicubic
+OpenJpegProcessor.downscale_filter = bicubic
+
+# Intensity of an unsharp mask from 0 to 1.
+OpenJpegProcessor.sharpen = 0
+
+#----------------------------------------
+# PdfBoxProcessor
+#----------------------------------------
+
+# Resolution of the PDF rasterization at a scale of 1. Requests for
+# scales less than 0.5 or larger than 2 will automatically use a lower or
+# higher factor of this.
+PdfBoxProcessor.dpi = 150
+
+# See Java2dProcessor.upscale_filter for a list of available filters.
+PdfBoxProcessor.upscale_filter = bicubic
+PdfBoxProcessor.downscale_filter = bicubic
+
+# Intensity of an unsharp mask from 0 to 1.
+PdfBoxProcessor.sharpen = 0
+
+###########################################################################
+# CLIENT-SIDE CACHING
+###########################################################################
+
+# Whether to enable the response Cache-Control header.
+cache.client.enabled = true
+
+cache.client.max_age = 2592000
+cache.client.shared_max_age =
+cache.client.public = true
+cache.client.private = false
+cache.client.no_cache = false
+cache.client.no_store = false
+cache.client.must_revalidate = false
+cache.client.proxy_revalidate = false
+cache.client.no_transform = true
+
+###########################################################################
+# SERVER-SIDE CACHING
+###########################################################################
+
+# Enables the source cache. The only available value is `FilesystemCache`.
+# Set blank to disable source image caching.
+# Note that source images will only be cached when a FileProcessor is used
+# with a StreamResolver, or when a StreamProcessor is used with
+# `StreamProcessor.retrieval_strategy` set to `CacheStrategy`.
+cache.source =
+
+# Enables the derivative (processed image) cache. Available values are
+# `FilesystemCache`, `JdbcCache`, `AmazonS3Cache`, and `AzureStorageCache`.
+# Set blank to disable derivative caching.
+cache.derivative = FilesystemCache
+
+# Time before a cached image becomes stale and needs to be reloaded. Set to
+# blank or 0 for infinite.
+cache.server.ttl_seconds = 2592000
+
+# If true, when a resolver reports that the requested source image has gone
+# missing, all cached information relating to it (if any) will be deleted.
+# (This is effectively always false when cache.server.resolve_first is also
+# false.)
+cache.server.purge_missing = false
+
+# If true, the source image will be confirmed to exist before a cached copy
+# is returned. If false, the cached copy will be returned without any
+# checking. Resolving first is slower but safer.
+cache.server.resolve_first = false
+
+# !! Enables the cache worker, which periodically purges expired cache
+# items in the background.
+cache.server.worker.enabled = false
+
+# !! The cache worker will wait this many seconds between purgings.
+cache.server.worker.interval = 86400
+
+#----------------------------------------
+# FilesystemCache
+#----------------------------------------
+
+# If this directory does not exist, it will be created automatically.
+FilesystemCache.pathname = /var/cache/cantaloupe
+
+# Levels of folder hierarchy in which to store cached images. Deeper depth
+# results in fewer files per directory. Set to 0 to disable subfolders.
+# Purge the cache after changing this.
+FilesystemCache.dir.depth = 3
+
+# Number of characters in hierarchy directory names. Should be set to
+# 16^n < (max number of directory entries your filesystem can deal with).
+# Purge the cache after changing this.
+FilesystemCache.dir.name_length = 2
+
+#----------------------------------------
+# JdbcCache
+#----------------------------------------
+
+# !!
+JdbcCache.url = jdbc:postgresql://localhost:5432/cantaloupe
+# !!
+JdbcCache.user = postgres
+# !!
+JdbcCache.password =
+
+# !! Connection timeout in seconds.
+JdbcCache.connection_timeout = 10
+
+# These must be created manually; see the user manual.
+JdbcCache.derivative_image_table = derivative_cache
+JdbcCache.info_table = info_cache
+
+#----------------------------------------
+# AmazonS3Cache
+#----------------------------------------
+
+# !! Access key ID and secret key associated with your AWS account.
+# See: http://aws.amazon.com/security-credentials
+AmazonS3Cache.access_key_id =
+AmazonS3Cache.secret_key =
+
+# !! Name of a bucket to use to hold cached data.
+AmazonS3Cache.bucket.name =
+
+# !! Can be left blank.
+# See: http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+AmazonS3Cache.bucket.region =
+
+# !! String that will be prefixed to object keys.
+AmazonS3Cache.object_key_prefix =
+
+#----------------------------------------
+# AzureStorageCache
+#----------------------------------------
+
+# !! Name of your Azure account.
+AzureStorageCache.account_name =
+
+# !! Key of your Azure account.
+AzureStorageCache.account_key =
+
+# !! Name of the container containing cached images.
+AzureStorageCache.container_name =
+
+# !! String that will be prefixed to object keys.
+AzureStorageCache.object_key_prefix =
+
+###########################################################################
+# OVERLAYS
+###########################################################################
+
+# Whether to enable overlays.
+overlays.enabled = false
+
+# Specifies how overlays are configured. `BasicStrategy` will use the
+# `overlays.BasicStrategy.*` keys in this section. `ScriptStrategy` will
+# use the `overlay` delegate method. See the user manual for more
+# information.
+overlays.strategy = BasicStrategy
+
+# `image` or `string`.
+overlays.BasicStrategy.type = image
+
+# Absolute path or URL of the overlay image. Must be a PNG file.
+overlays.BasicStrategy.image = /path/to/overlay.png
+
+# Overlay text.
+overlays.BasicStrategy.string = Copyright \u00A9️ My Great Organization\nAll rights reserved.
+
+# For possible values, launch with the -Dcantaloupe.list_fonts option.
+overlays.BasicStrategy.string.font = Helvetica
+
+# Font size in points.
+overlays.BasicStrategy.string.font.size = 18
+
+# Color name, rgb(r,g,b), and #rrggbb syntax are supported.
+overlays.BasicStrategy.string.color = white
+
+# Color name, rgb(r,g,b), and #rrggbb syntax are supported.
+overlays.BasicStrategy.string.stroke.color = black
+
+# Stroke width in pixels.
+overlays.BasicStrategy.string.stroke.width = 1
+
+# Allowed values: `top left`, `top center`, `top right`, `left center`,
+# `center`, `right center`, `bottom left`, `bottom center`, `bottom right`.
+overlays.BasicStrategy.position = bottom right
+
+# Pixel margin between the overlay and the image edge.
+overlays.BasicStrategy.inset = 10
+
+# Output images less than this many pixels wide will not receive an overlay.
+# Set to 0 to add the overlay regardless.
+overlays.BasicStrategy.output_width_threshold = 400
+
+# Output images less than this many pixels tall will not receive an overlay.
+# Set to 0 to add the overlay regardless.
+overlays.BasicStrategy.output_height_threshold = 300
+
+###########################################################################
+# REDACTIONS
+###########################################################################
+
+# Whether to enable redactions. See the user manual for information about
+# how these work.
+redaction.enabled = false
+
+###########################################################################
+# METADATA
+###########################################################################
+
+# Whether to attempt to copy source image metadata (EXIF, IPTC, XMP) into
+# derivative images. (This is not foolproof; see the user manual.)
+metadata.preserve = false
+
+# Whether to respect the EXIF "Orientation" field to auto-rotate images.
+# The check for this field can impair performance slightly.
+metadata.respect_orientation = false
+
+###########################################################################
+# LOGGING
+###########################################################################
+
+#----------------------------------------
+# Application Log
+#----------------------------------------
+
+# `trace`, `debug`, `info`, `warn`, `error`, `all`, or `off`
+log.application.level = debug
+
+log.application.ConsoleAppender.enabled = true
+
+log.application.FileAppender.enabled = false
+log.application.FileAppender.pathname = /path/to/logs/application.log
+
+# RollingFileAppender is an alternative to using something like
+# FileAppender + logrotate.
+log.application.RollingFileAppender.enabled = false
+log.application.RollingFileAppender.pathname = /path/to/logs/application.log
+log.application.RollingFileAppender.policy = TimeBasedRollingPolicy
+log.application.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = /path/to/logs/application-%d{yyyy-MM-dd}.log
+log.application.RollingFileAppender.TimeBasedRollingPolicy.max_history = 30
+
+# See the "SyslogAppender" section for a list of facilities:
+# http://logback.qos.ch/manual/appenders.html
+log.application.SyslogAppender.enabled = false
+log.application.SyslogAppender.host =
+log.application.SyslogAppender.port = 514
+log.application.SyslogAppender.facility = LOCAL0
+
+#----------------------------------------
+# Access Log
+#----------------------------------------
+
+log.access.ConsoleAppender.enabled = true
+
+log.access.FileAppender.enabled = false
+log.access.FileAppender.pathname = /path/to/logs/access.log
+
+# RollingFileAppender is an alternative to using something like
+# FileAppender + logrotate.
+log.access.RollingFileAppender.enabled = false
+log.access.RollingFileAppender.pathname = /path/to/logs/access.log
+log.access.RollingFileAppender.policy = TimeBasedRollingPolicy
+log.access.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = /path/to/logs/access-%d{yyyy-MM-dd}.log
+log.access.RollingFileAppender.TimeBasedRollingPolicy.max_history = 30
+
+# See the "SyslogAppender" section for a list of facilities:
+# http://logback.qos.ch/manual/appenders.html
+log.access.SyslogAppender.enabled = false
+log.access.SyslogAppender.host =
+log.access.SyslogAppender.port = 514
+log.access.SyslogAppender.facility = LOCAL0


### PR DESCRIPTION
Added a simple dockerfile to run and test cantaloupe with a docker daemon / docker native. For quickly getting started with local testing.

Build local docker image (tested on OS X with docker native 1.12.5):
`$ sudo docker build -t cantaloupe .`

Run docker image with local images volume:
`$ sudo docker run -d -p 8183:8182 -v ./images:/var/lib/cantaloupe/images --name cantaloupe cantaloupe`