### PR TITLE
Make javax.servlet-api provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,14 +157,11 @@
       <artifactId>imageio-ext-tiff</artifactId>
       <version>1.1.17</version>
     </dependency>
-    <!--
-    This will need to be excluded from WEB-INF/lib during the package
-    phase, but an exploded version included in the root for standalone mode.
-    -->
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>3.1.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -478,7 +475,6 @@
                   <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                 </manifest>
               </archive>
-              <packagingExcludes>WEB-INF/lib/javax.servlet-api-*.jar</packagingExcludes>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
The javax.servlet-api jar was scoped to compile, and because of this I couldn't run Cantaloupe in Eclipse. When trying to run with `mvn clean tomcat:run` I got:

```
Jul 25, 2017 12:52:48 PM org.apache.catalina.core.StandardContext loadOnStartup
SEVERE: Servlet /Cantaloupe threw load() exception
java.lang.ClassCastException: edu.illinois.library.cantaloupe.EntryServlet cannot be cast to javax.servlet.Servlet
	at org.apache.catalina.core.StandardWrapper.loadServlet(StandardWrapper.java:1116)
	at org.apache.catalina.core.StandardWrapper.load(StandardWrapper.java:993)
	at org.apache.catalina.core.StandardContext.loadOnStartup(StandardContext.java:4350)
```

Marking it as provided, everything works in Eclipse. Running `mvn clean package -DskipTests`, I get the `.war` and `.zip` files.

Comparing the WAR and ZIP files, with the contents of Cantaloupe-3.3.2.zip that I just downloaded, everything looks fine. I cannot find the servlet JAR in there. And in the root of the WAR I can see the javax folder. Same for the WAR file within the ZIP.

Am I missing anything? Is that an OK change? If so, it would be easier for users running `mvn tomcat:run` (or jetty, winstone, etc) to develop new features and test :-)

Thanks
Bruno