### PR TITLE
Use ServletContextInitializer for application initialization

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/ApplicationInitializer.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/ApplicationInitializer.java
@@ -1,0 +1,193 @@
+package edu.illinois.library.cantaloupe;
+
+import java.io.FileNotFoundException;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import org.apache.velocity.app.Velocity;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.illinois.library.cantaloupe.cache.Cache;
+import edu.illinois.library.cantaloupe.cache.CacheException;
+import edu.illinois.library.cantaloupe.cache.CacheFactory;
+import edu.illinois.library.cantaloupe.cache.CacheWorkerRunner;
+import edu.illinois.library.cantaloupe.config.ConfigurationFactory;
+import edu.illinois.library.cantaloupe.image.Identifier;
+import edu.illinois.library.cantaloupe.logging.LoggerUtil;
+import edu.illinois.library.cantaloupe.logging.velocity.Slf4jLogChute;
+import edu.illinois.library.cantaloupe.script.DelegateScriptDisabledException;
+import edu.illinois.library.cantaloupe.script.ScriptEngineFactory;
+
+/**
+ * <p>Performs application initialization that cannot be performed
+ * in {@link StandaloneEntry} as that class is not available in a Servlet
+ * container context.</p>
+ */
+public class ApplicationInitializer implements ServletContextListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationInitializer.class);
+
+    static final String CLEAN_CACHE_VM_ARGUMENT = "cantaloupe.cache.clean";
+    static final String PURGE_CACHE_VM_ARGUMENT = "cantaloupe.cache.purge";
+    static final String PURGE_EXPIRED_FROM_CACHE_VM_ARGUMENT =
+            "cantaloupe.cache.purge_expired";
+
+    static {
+        // Suppress a Dock icon in OS X
+        System.setProperty("java.awt.headless", "true");
+
+        // Tell Restlet to use SLF4J instead of java.util.logging. This needs
+        // to be performed before Restlet has been initialized.
+        System.setProperty("org.restlet.engine.loggerFacadeClass",
+                "org.restlet.ext.slf4j.Slf4jLoggerFacade");
+    }
+
+    private void handleVmArguments() {
+        try {
+            if (System.getProperty(CLEAN_CACHE_VM_ARGUMENT) != null) {
+                Cache cache = CacheFactory.getSourceCache();
+                if (cache != null) {
+                    System.out.println("Cleaning the source cache...");
+                    cache.cleanUp();
+                } else {
+                    System.out.println("Source cache is disabled.");
+                }
+                cache = CacheFactory.getDerivativeCache();
+                if (cache != null) {
+                    System.out.println("Cleaning the derivative cache...");
+                    cache.cleanUp();
+                } else {
+                    System.out.println("Derivative cache is disabled.");
+                }
+                System.out.println("Done.");
+                System.exit(0);
+            } else if (System.getProperty(PURGE_CACHE_VM_ARGUMENT) != null) {
+                // Two variants of this argument are supported:
+                // -Dcantaloupe.cache.purge (purge everything)
+                // -Dcantaloupe.cache.purge=identifier (purge all content
+                // related to the given identifier)
+                final String purgeArg =
+                        System.getProperty(PURGE_CACHE_VM_ARGUMENT);
+                if (purgeArg.length() > 0) {
+                    Identifier identifier = new Identifier(purgeArg);
+                    Cache cache = CacheFactory.getSourceCache();
+                    if (cache != null) {
+                        System.out.println("Purging " + identifier +
+                                " from the source cache...");
+                        cache.purge(identifier);
+                    } else {
+                        System.out.println("Source cache is disabled.");
+                    }
+                    cache = CacheFactory.getDerivativeCache();
+                    if (cache != null) {
+                        System.out.println("Purging " + identifier +
+                                " from the derivative cache...");
+                        cache.purge(identifier);
+                    } else {
+                        System.out.println("Derivative cache is disabled.");
+                    }
+                } else {
+                    Cache cache = CacheFactory.getSourceCache();
+                    if (cache != null) {
+                        System.out.println("Purging the source cache...");
+                        cache.purge();
+                    } else {
+                        System.out.println("Source cache is disabled.");
+                    }
+                    cache = CacheFactory.getDerivativeCache();
+                    if (cache != null) {
+                        System.out.println("Purging the derivative cache...");
+                        cache.purge();
+                    } else {
+                        System.out.println("Derivative cache is disabled.");
+                    }
+                }
+                System.out.println("Done.");
+                System.exit(0);
+            } else if (System.getProperty(PURGE_EXPIRED_FROM_CACHE_VM_ARGUMENT) != null) {
+                Cache cache = CacheFactory.getSourceCache();
+                if (cache != null) {
+                    System.out.println("Purging expired items from the source cache...");
+                    cache.purgeExpired();
+                } else {
+                    System.out.println("Source cache is disabled.");
+                }
+                cache = CacheFactory.getDerivativeCache();
+                if (cache != null) {
+                    System.out.println("Purging expired items from the derivative cache...");
+                    cache.purgeExpired();
+                } else {
+                    System.out.println("Derivative cache is disabled.");
+                }
+                System.out.println("Done.");
+                System.exit(0);
+            }
+        } catch (CacheException e) {
+            System.out.println(e.getMessage());
+            System.exit(-1);
+        }
+    }
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        // Logback has already initialized itself, which is a problem because
+        // logback.xml depends on the application configuration, which at the
+        // time, had not been initialized yet. So, reload it.
+        LoggerUtil.reloadConfiguration();
+
+        Velocity.setProperty(RuntimeConstants.RESOURCE_LOADER, "classpath");
+        Velocity.setProperty("classpath.resource.loader.class",
+                ClasspathResourceLoader.class.getName());
+        Velocity.setProperty("class.resource.loader.cache", true);
+        Velocity.setProperty("runtime.log.logsystem.class",
+                Slf4jLogChute.class.getCanonicalName());
+        Velocity.init();
+
+        final int mb = 1024 * 1024;
+        final Runtime runtime = Runtime.getRuntime();
+        LOGGER.info(System.getProperty("java.vm.name") + " / " +
+                System.getProperty("java.vm.info"));
+        LOGGER.info("{} available processor cores",
+                runtime.availableProcessors());
+        LOGGER.info("Heap total: {}MB; max: {}MB", runtime.totalMemory() / mb,
+                runtime.maxMemory() / mb);
+        LOGGER.info("\uD83C\uDF48 Starting Cantaloupe {}",
+                Application.getVersion());
+
+        handleVmArguments();
+
+        ConfigurationFactory.getInstance().startWatching();
+        CacheWorkerRunner.start();
+        try {
+            ScriptEngineFactory.getScriptEngine().startWatching();
+        } catch (DelegateScriptDisabledException e) {
+            LOGGER.info("init(): {}", e.getMessage());
+        } catch (FileNotFoundException e) {
+            LOGGER.error("init(): file not found: {}", e.getMessage());
+        } catch (Exception e) {
+            LOGGER.error("init(): {}", e.getMessage());
+        }
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+        LOGGER.info("Shutting down...");
+        CacheWorkerRunner.stop();
+        ConfigurationFactory.getInstance().stopWatching();
+        ThreadPool.getInstance().shutdown();
+        try {
+            ScriptEngineFactory.getScriptEngine().stopWatching();
+        } catch (DelegateScriptDisabledException e) {
+            LOGGER.info("init(): {}", e.getMessage());
+        } catch (FileNotFoundException e) {
+            LOGGER.error("destroy(): file not found: {}", e.getMessage());
+        } catch (Exception e) {
+            LOGGER.error("destroy(): {}", e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/edu/illinois/library/cantaloupe/EntryServlet.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/EntryServlet.java
@@ -1,31 +1,13 @@
 package edu.illinois.library.cantaloupe;
 
-import edu.illinois.library.cantaloupe.cache.Cache;
-import edu.illinois.library.cantaloupe.cache.CacheException;
-import edu.illinois.library.cantaloupe.cache.CacheFactory;
-import edu.illinois.library.cantaloupe.cache.CacheWorkerRunner;
-import edu.illinois.library.cantaloupe.config.ConfigurationFactory;
-import edu.illinois.library.cantaloupe.logging.LoggerUtil;
-import edu.illinois.library.cantaloupe.image.Identifier;
-import edu.illinois.library.cantaloupe.logging.velocity.Slf4jLogChute;
-import edu.illinois.library.cantaloupe.script.DelegateScriptDisabledException;
-import edu.illinois.library.cantaloupe.script.ScriptEngineFactory;
-import org.apache.velocity.app.Velocity;
-import org.apache.velocity.runtime.RuntimeConstants;
-import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
 import org.restlet.data.Protocol;
 import org.restlet.ext.servlet.ServerServlet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletException;
-import java.io.FileNotFoundException;
 
 /**
  * <p>Serves as the entry Servlet in both standalone and Servlet container
- * context. Also performs application initialization that cannot be performed
- * in {@link StandaloneEntry} as that class is not available in a Servlet
- * container context.</p>
+ * context.</p>
  *
  * <p>Because this is a Restlet application, there are no other Servlet
  * classes. Instead there are Restlet resource classes residing in
@@ -33,169 +15,13 @@ import java.io.FileNotFoundException;
  */
 public class EntryServlet extends ServerServlet {
 
-    private static Logger logger = LoggerFactory.getLogger(EntryServlet.class);
-
-    static final String CLEAN_CACHE_VM_ARGUMENT = "cantaloupe.cache.clean";
-    static final String PURGE_CACHE_VM_ARGUMENT = "cantaloupe.cache.purge";
-    static final String PURGE_EXPIRED_FROM_CACHE_VM_ARGUMENT =
-            "cantaloupe.cache.purge_expired";
-
-    static {
-        // Suppress a Dock icon in OS X
-        System.setProperty("java.awt.headless", "true");
-
-        // Tell Restlet to use SLF4J instead of java.util.logging. This needs
-        // to be performed before Restlet has been initialized.
-        System.setProperty("org.restlet.engine.loggerFacadeClass",
-                "org.restlet.ext.slf4j.Slf4jLoggerFacade");
-    }
-
-    private void handleVmArguments() {
-        try {
-            if (System.getProperty(CLEAN_CACHE_VM_ARGUMENT) != null) {
-                Cache cache = CacheFactory.getSourceCache();
-                if (cache != null) {
-                    System.out.println("Cleaning the source cache...");
-                    cache.cleanUp();
-                } else {
-                    System.out.println("Source cache is disabled.");
-                }
-                cache = CacheFactory.getDerivativeCache();
-                if (cache != null) {
-                    System.out.println("Cleaning the derivative cache...");
-                    cache.cleanUp();
-                } else {
-                    System.out.println("Derivative cache is disabled.");
-                }
-                System.out.println("Done.");
-                System.exit(0);
-            } else if (System.getProperty(PURGE_CACHE_VM_ARGUMENT) != null) {
-                // Two variants of this argument are supported:
-                // -Dcantaloupe.cache.purge (purge everything)
-                // -Dcantaloupe.cache.purge=identifier (purge all content
-                // related to the given identifier)
-                final String purgeArg =
-                        System.getProperty(PURGE_CACHE_VM_ARGUMENT);
-                if (purgeArg.length() > 0) {
-                    Identifier identifier = new Identifier(purgeArg);
-                    Cache cache = CacheFactory.getSourceCache();
-                    if (cache != null) {
-                        System.out.println("Purging " + identifier +
-                                " from the source cache...");
-                        cache.purge(identifier);
-                    } else {
-                        System.out.println("Source cache is disabled.");
-                    }
-                    cache = CacheFactory.getDerivativeCache();
-                    if (cache != null) {
-                        System.out.println("Purging " + identifier +
-                                " from the derivative cache...");
-                        cache.purge(identifier);
-                    } else {
-                        System.out.println("Derivative cache is disabled.");
-                    }
-                } else {
-                    Cache cache = CacheFactory.getSourceCache();
-                    if (cache != null) {
-                        System.out.println("Purging the source cache...");
-                        cache.purge();
-                    } else {
-                        System.out.println("Source cache is disabled.");
-                    }
-                    cache = CacheFactory.getDerivativeCache();
-                    if (cache != null) {
-                        System.out.println("Purging the derivative cache...");
-                        cache.purge();
-                    } else {
-                        System.out.println("Derivative cache is disabled.");
-                    }
-                }
-                System.out.println("Done.");
-                System.exit(0);
-            } else if (System.getProperty(PURGE_EXPIRED_FROM_CACHE_VM_ARGUMENT) != null) {
-                Cache cache = CacheFactory.getSourceCache();
-                if (cache != null) {
-                    System.out.println("Purging expired items from the source cache...");
-                    cache.purgeExpired();
-                } else {
-                    System.out.println("Source cache is disabled.");
-                }
-                cache = CacheFactory.getDerivativeCache();
-                if (cache != null) {
-                    System.out.println("Purging expired items from the derivative cache...");
-                    cache.purgeExpired();
-                } else {
-                    System.out.println("Derivative cache is disabled.");
-                }
-                System.out.println("Done.");
-                System.exit(0);
-            }
-        } catch (CacheException e) {
-            System.out.println(e.getMessage());
-            System.exit(-1);
-        }
-    }
+    private static final long serialVersionUID = 5627021158653885870L;
 
     @Override
     public void init() throws ServletException {
         super.init();
 
-        // Logback has already initialized itself, which is a problem because
-        // logback.xml depends on the application configuration, which at the
-        // time, had not been initialized yet. So, reload it.
-        LoggerUtil.reloadConfiguration();
-
-        Velocity.setProperty(RuntimeConstants.RESOURCE_LOADER, "classpath");
-        Velocity.setProperty("classpath.resource.loader.class",
-                ClasspathResourceLoader.class.getName());
-        Velocity.setProperty("class.resource.loader.cache", true);
-        Velocity.setProperty("runtime.log.logsystem.class",
-                Slf4jLogChute.class.getCanonicalName());
-        Velocity.init();
-
-        final int mb = 1024 * 1024;
-        final Runtime runtime = Runtime.getRuntime();
-        logger.info(System.getProperty("java.vm.name") + " / " +
-                System.getProperty("java.vm.info"));
-        logger.info("{} available processor cores",
-                runtime.availableProcessors());
-        logger.info("Heap total: {}MB; max: {}MB", runtime.totalMemory() / mb,
-                runtime.maxMemory() / mb);
-        logger.info("\uD83C\uDF48 Starting Cantaloupe {}",
-                Application.getVersion());
-
         getComponent().getClients().add(Protocol.CLAP);
-
-        handleVmArguments();
-        ConfigurationFactory.getInstance().startWatching();
-        CacheWorkerRunner.start();
-        try {
-            ScriptEngineFactory.getScriptEngine().startWatching();
-        } catch (DelegateScriptDisabledException e) {
-            logger.info("init(): {}", e.getMessage());
-        } catch (FileNotFoundException e) {
-            logger.error("init(): file not found: {}", e.getMessage());
-        } catch (Exception e) {
-            logger.error("init(): {}", e.getMessage());
-        }
-    }
-
-    @Override
-    public void destroy() {
-        logger.info("Shutting down...");
-        super.destroy();
-        CacheWorkerRunner.stop();
-        ConfigurationFactory.getInstance().stopWatching();
-        ThreadPool.getInstance().shutdown();
-        try {
-            ScriptEngineFactory.getScriptEngine().stopWatching();
-        } catch (DelegateScriptDisabledException e) {
-            logger.info("init(): {}", e.getMessage());
-        } catch (FileNotFoundException e) {
-            logger.error("destroy(): file not found: {}", e.getMessage());
-        } catch (Exception e) {
-            logger.error("destroy(): {}", e.getMessage());
-        }
     }
 
 }

--- a/src/main/java/edu/illinois/library/cantaloupe/StandaloneEntry.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/StandaloneEntry.java
@@ -145,13 +145,13 @@ public class StandaloneEntry {
                 "VM options:\n" +
                 "-D" + ConfigurationFactory.CONFIG_VM_ARGUMENT + "=<config>" +
                 "           Configuration file (REQUIRED)\n" +
-                "-D" + EntryServlet.PURGE_CACHE_VM_ARGUMENT +
+                "-D" + ApplicationInitializer.PURGE_CACHE_VM_ARGUMENT +
                 "               Purge the cache\n" +
-                "-D" + EntryServlet.PURGE_CACHE_VM_ARGUMENT + "=<identifier>" +
+                "-D" + ApplicationInitializer.PURGE_CACHE_VM_ARGUMENT + "=<identifier>" +
                 "  Purge items related to an identifier from the cache\n" +
-                "-D" + EntryServlet.PURGE_EXPIRED_FROM_CACHE_VM_ARGUMENT +
+                "-D" + ApplicationInitializer.PURGE_EXPIRED_FROM_CACHE_VM_ARGUMENT +
                 "       Purge expired items from the cache\n" +
-                "-D" + EntryServlet.CLEAN_CACHE_VM_ARGUMENT +
+                "-D" + ApplicationInitializer.CLEAN_CACHE_VM_ARGUMENT +
                 "               Clean the cache\n" +
                 "-D" + StandaloneEntry.LIST_FONTS_VM_OPTION +
                 "                List fonts\n";

--- a/src/main/java/edu/illinois/library/cantaloupe/config/ConfigurationFactory.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/config/ConfigurationFactory.java
@@ -1,7 +1,5 @@
 package edu.illinois.library.cantaloupe.config;
 
-import java.io.IOException;
-
 public abstract class ConfigurationFactory {
 
     public static final String CONFIG_VM_ARGUMENT = "cantaloupe.config";
@@ -40,7 +38,7 @@ public abstract class ConfigurationFactory {
                         }
                         instance = config;
                     } else {
-                        System.err.println("ConfigurationFactory.getInstance(): " +
+                        throw new RuntimeException("ConfigurationFactory.getInstance(): " +
                                 "missing " + CONFIG_VM_ARGUMENT + " VM option.");
                     }
                 }

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -11,6 +11,11 @@
         <param-value>edu.illinois.library.cantaloupe.RestletApplication</param-value>
     </context-param>
 
+    <listener>
+        <display-name>ApplicationInitializer</display-name>
+        <listener-class>edu.illinois.library.cantaloupe.ApplicationInitializer</listener-class>
+    </listener>
+
     <servlet>
         <servlet-name>ServerServlet</servlet-name>
         <servlet-class>edu.illinois.library.cantaloupe.EntryServlet</servlet-class>
@@ -18,7 +23,6 @@
             <param-name>org.restlet.clients</param-name>
             <param-value>CLAP HTTP HTTPS</param-value>
         </init-param>
-        <load-on-startup>0</load-on-startup>
     </servlet>
 
     <servlet-mapping>

--- a/src/test/java/edu/illinois/library/cantaloupe/StandaloneEntryTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/StandaloneEntryTest.java
@@ -112,9 +112,9 @@ public class StandaloneEntryTest extends BaseTest {
         httpClient.stop();
         deleteCacheDir();
         System.clearProperty(ConfigurationFactory.CONFIG_VM_ARGUMENT);
-        System.clearProperty(EntryServlet.CLEAN_CACHE_VM_ARGUMENT);
-        System.clearProperty(EntryServlet.PURGE_CACHE_VM_ARGUMENT);
-        System.clearProperty(EntryServlet.PURGE_EXPIRED_FROM_CACHE_VM_ARGUMENT);
+        System.clearProperty(ApplicationInitializer.CLEAN_CACHE_VM_ARGUMENT);
+        System.clearProperty(ApplicationInitializer.PURGE_CACHE_VM_ARGUMENT);
+        System.clearProperty(ApplicationInitializer.PURGE_EXPIRED_FROM_CACHE_VM_ARGUMENT);
         System.clearProperty(StandaloneEntry.LIST_FONTS_VM_OPTION);
         resetOutput();
     }
@@ -240,7 +240,7 @@ public class StandaloneEntryTest extends BaseTest {
 
         // TODO: write this
 
-        System.setProperty(EntryServlet.CLEAN_CACHE_VM_ARGUMENT, "");
+        System.setProperty(ApplicationInitializer.CLEAN_CACHE_VM_ARGUMENT, "");
         StandaloneEntry.main(new String[] {});
 
         // Cause the Servlet to be loaded
@@ -291,7 +291,7 @@ public class StandaloneEntryTest extends BaseTest {
         assertEquals(1, FileUtils.listFiles(infoDir, null, true).size());
 
         // purge the cache
-        System.setProperty(EntryServlet.PURGE_CACHE_VM_ARGUMENT, "");
+        System.setProperty(ApplicationInitializer.PURGE_CACHE_VM_ARGUMENT, "");
         StandaloneEntry.main(new String[] {});
 
         // Cause the Servlet to be loaded
@@ -352,7 +352,7 @@ public class StandaloneEntryTest extends BaseTest {
         assertEquals(2, FileUtils.listFiles(infoDir, null, true).size());
 
         // purge one identifier
-        System.setProperty(EntryServlet.PURGE_CACHE_VM_ARGUMENT, "dogs");
+        System.setProperty(ApplicationInitializer.PURGE_CACHE_VM_ARGUMENT, "dogs");
         StandaloneEntry.main(new String[] {});
 
         // Cause the Servlet to be loaded
@@ -398,7 +398,7 @@ public class StandaloneEntryTest extends BaseTest {
         File.createTempFile("bla2", "tmp", imageDir);
         File.createTempFile("bla2", "tmp", infoDir);
 
-        System.setProperty(EntryServlet.PURGE_EXPIRED_FROM_CACHE_VM_ARGUMENT, "");
+        System.setProperty(ApplicationInitializer.PURGE_EXPIRED_FROM_CACHE_VM_ARGUMENT, "");
         StandaloneEntry.main(new String[] {});
 
         // Cause the Servlet to be loaded


### PR DESCRIPTION
Hi,

This commit introduces a new `ServletContextListener`, `ApplicationInitializer`, which offloads parts of the responsibilities from `EntryServlet`. The `EntryServlet` was both serving as Jersey entry point servlet, but also as handling application initialization.

This is now done in the listener. The `ConfigurationFactory` is also throwing an exception when there is no configuration file, instead of printing to `stderr` and later throwing a `NullPointerException`.

With these changes, it is easy to identify when the application fails to initialize. Which is useful when a WAR application is deployed to a platform like AWS Elastic Beanstalk.