### PR TITLE
Use a test profile, and fix some tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,15 @@ Any that are missing will cause the corresponding test in parentheses to fail.
 Then, copy `test.properties.sample` to `test.properties` and fill in whatever
 info you have. Same story as above: missing info will cause errors.
 
-Finally, `mvn test` will run the tests.
+Finally, `mvn clean test` will run the tests. This will run the complete suite of tests.
+You can also choose to run a subset of the tests. 
+
+For running just the tests that have no dependencies to third-party services, or
+require tools and/or libraries to be installed, you can run `mvn clean test -Pnodeps`.
+
+If you have the open source and free tools and libraries installed (e.g. FFmpeg,
+GraphicsMagick, ImageMagick, OpenJPEG), then you can run `mvn clean test -Pfreedeps`.
+This is the command executed for continuous integration.
 
 ## Build the website
 

--- a/pom.xml
+++ b/pom.xml
@@ -526,4 +526,33 @@
 
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>nodeps</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.19.1</version>
+            <configuration>
+              <runOrder>random</runOrder>
+              <reuseForks>false</reuseForks>
+              <excludes>
+                <exclude>Azure*Test</exclude>
+                <exclude>Amazon*Test</exclude>
+                <exclude>Kakadu*Test</exclude>
+                <exclude>Redis*Test</exclude>
+                <exclude>ControlPanelTest</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -543,8 +543,37 @@
               <runOrder>random</runOrder>
               <reuseForks>false</reuseForks>
               <excludes>
-                <exclude>Azure*Test</exclude>
+                <exclude>AmazonS3*Test</exclude>
+                <exclude>AzureStorage*Test</exclude>
+                <exclude>FfmpegProcessorTest</exclude>
+                <exclude>GraphicsMagickProcessorTest</exclude>
+                <exclude>ImageMagickProcessorTest</exclude>
+                <exclude>KakaduProcessorTest</exclude>
+                <exclude>OpenJpegProcessorTest</exclude>
+                <exclude>RedisCacheTest</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>freedeps</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.19.1</version>
+            <configuration>
+              <runOrder>random</runOrder>
+              <reuseForks>false</reuseForks>
+              <excludes>
                 <exclude>Amazon*Test</exclude>
+                <exclude>Azure*Test</exclude>
                 <exclude>Kakadu*Test</exclude>
                 <exclude>Redis*Test</exclude>
                 <exclude>ControlPanelTest</exclude>

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/overlay/StringOverlay.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/overlay/StringOverlay.java
@@ -130,7 +130,7 @@ public class StringOverlay extends Overlay implements Operation {
         map.put("background_color", getBackgroundColor().toRGBAHex());
         map.put("class", getClass().getSimpleName());
         map.put("color", getColor().toRGBAHex());
-        map.put("font", getFont().getFamily());
+        map.put("font", getFont().getName());
         map.put("font_size", getFont().getSize());
         map.put("font_weight",
                 getFont().getAttributes().get(TextAttribute.WEIGHT));
@@ -166,7 +166,7 @@ public class StringOverlay extends Overlay implements Operation {
                 string,
                 getPosition(),
                 getInset(),
-                getFont().getFamily(),
+                getFont().getName(),
                 getFont().getSize(),
                 getFont().getAttributes().get(TextAttribute.WEIGHT),
                 getFont().getAttributes().get(TextAttribute.TRACKING),

--- a/src/test/java/edu/illinois/library/cantaloupe/operation/overlay/BasicStringOverlayServiceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/operation/overlay/BasicStringOverlayServiceTest.java
@@ -51,7 +51,7 @@ public class BasicStringOverlayServiceTest extends BaseTest {
         assertEquals("cats", overlay.getString());
         assertEquals(new Color(12, 23, 34, 45), overlay.getBackgroundColor());
         assertEquals(Color.red, overlay.getColor());
-        assertEquals("Helvetica", overlay.getFont().getFamily());
+        assertEquals("Helvetica", overlay.getFont().getName());
         assertEquals((long) 10, overlay.getInset());
         assertEquals(Position.TOP_LEFT, overlay.getPosition());
         assertEquals(14, overlay.getFont().getSize());

--- a/src/test/java/edu/illinois/library/cantaloupe/operation/overlay/DelegateOverlayServiceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/operation/overlay/DelegateOverlayServiceTest.java
@@ -6,7 +6,6 @@ import edu.illinois.library.cantaloupe.config.Key;
 import edu.illinois.library.cantaloupe.image.Format;
 import edu.illinois.library.cantaloupe.image.Identifier;
 import edu.illinois.library.cantaloupe.operation.OperationList;
-import edu.illinois.library.cantaloupe.script.ScriptEngineFactory;
 import edu.illinois.library.cantaloupe.test.BaseTest;
 import edu.illinois.library.cantaloupe.test.TestUtil;
 import org.junit.Before;
@@ -70,7 +69,7 @@ public class DelegateOverlayServiceTest extends BaseTest {
                 opList, fullSize, requestUrl, requestHeaders, clientIp,
                 cookies);
         assertEquals("dogs\ndogs", overlay.getString());
-        assertEquals("Helvetica", overlay.getFont().getFamily());
+        assertEquals("Helvetica", overlay.getFont().getName());
         assertEquals(20, overlay.getFont().getSize());
         assertEquals(11, overlay.getMinSize());
         assertEquals(1.5f, overlay.getFont().getAttributes().get(TextAttribute.WEIGHT));

--- a/src/test/java/edu/illinois/library/cantaloupe/operation/overlay/StringOverlayTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/operation/overlay/StringOverlayTest.java
@@ -23,7 +23,7 @@ public class StringOverlayTest extends BaseTest {
         super.setUp();
 
         final Map<TextAttribute, Object> attributes = new HashMap<>();
-        attributes.put(TextAttribute.FAMILY, "Helvetica");
+        attributes.put(TextAttribute.FAMILY, "Arial");
         attributes.put(TextAttribute.SIZE, 12);
         attributes.put(TextAttribute.WEIGHT, 2.0f);
         attributes.put(TextAttribute.TRACKING, 0.1f);
@@ -66,7 +66,7 @@ public class StringOverlayTest extends BaseTest {
     @Test
     public void testToString() throws IOException {
         instance.setString("DOGSdogs123!@#$%\n%^&*()");
-        assertEquals("801774c691b35cbd89e3bd8cb6803681_SE_5_Helvetica_12_2.0_0.1_#0000FFFF_#FFA500FF_#FF0000FF_5.0",
+        assertEquals("801774c691b35cbd89e3bd8cb6803681_SE_5_Arial_12_2.0_0.1_#0000FFFF_#FFA500FF_#FF0000FF_5.0",
                 instance.toString());
     }
 

--- a/src/test/java/edu/illinois/library/cantaloupe/operation/overlay/StringOverlayTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/operation/overlay/StringOverlayTest.java
@@ -49,7 +49,7 @@ public class StringOverlayTest extends BaseTest {
         assertEquals(instance.getBackgroundColor().toRGBAHex(),
                 map.get("background_color"));
         assertEquals(instance.getColor().toRGBAHex(), map.get("color"));
-        assertEquals(instance.getFont().getFamily(), map.get("font"));
+        assertEquals(instance.getFont().getName(), map.get("font"));
         assertEquals(instance.getFont().getSize(), map.get("font_size"));
         assertEquals(instance.getFont().getAttributes().get(TextAttribute.WEIGHT),
                 map.get("font_weight"));


### PR DESCRIPTION
Right now I have one test failing. This PR includes a `nodeps` profile as discussed in #130, for running the unit tests that do not require external accounts in AWS/Azure/etc, nor certain dependencies such as Kakadu or Selenium.

There are also several tests that use font family, and not family name. The problem with that is that the value changes quite a bit in Linux/Windows. So this PR also addresses this problem, by using the font name.

The Helvetica font is not installed in Ubuntu, or at least is not easily installed. Tried the `ms-mscorefonts-installer` but didn't get the Helvetica font, so changed by Arial.