### PR TITLE
Add Travis CI to the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: java
+sudo: required
+# trusty is required for oraclejdk9
+dist: trusty
+
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+
+before_install:
+  # copy properties file
+  - cp test.properties.sample test.properties
+  # trusty used avconv, not ffmpeg, and tools like ffprobe are missing. So we need to add this repo
+  - sudo add-apt-repository -y ppa:mc3man/trusty-media
+  # no openjpeg2000 tools like opj_decompress for trusty as well, so adding this repo
+  - sudo apt-get install apt-transport-https
+  - wget -O - https://notesalexp.org/debian/alexp_key.asc | sudo apt-key add -
+  - sudo apt-add-repository 'deb https://notesalexp.org/debian/trusty trusty main'
+  # update and install all packages
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libav-tools graphicsmagick imagemagick ffmpeg libopenjp2-tools
+
+script:
+  - mvn clean verify -Pfreedeps
+
+#after_success:
+#  - mvn clean cobertura:cobertura coveralls:report

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/medusa-project/cantaloupe.svg?branch=develop)](https://travis-ci.org/medusa-project/cantaloupe)
+
 # 🍈 Cantaloupe
 
 *High-performance dynamic image server in Java*


### PR DESCRIPTION
Hi,

This pull request adds automated continuous integration through [Travis CI](https://docs.travis-ci.com/user/getting-started/). There is a YAML file, _.travis.yml_ that contains the configuration for Travis CI. And in the README.md, we have a new line that adds the image badge.

It is possible to view what the badge will look like on this branch [https://github.com/kinow/cantaloupe/tree/add-travis](https://github.com/kinow/cantaloupe/tree/add-travis). Look at the README, scrolling down a bit the page.

In order to enable it, you - or another person with administrator rights in GitHub for the repository - would have to go to https://travis-ci.org/, log in with GitHub, look for the medusa-project/cantaloupe-project, and enable it.

There are a few settings in Travis CI that you may be interested in changing, like which branches must be monitored, whether you'd like to have pull requests being tested by it (I personally find it quite useful), etc.

This PR probably depends on https://github.com/medusa-project/cantaloupe/pull/136, to have the `freedeps` Maven profile, which restricts which test are executed.

Travis utilises Ubuntu Trusty, which was *fun* to set up Ffmpeg and OpenJPEG2000. Had to play a few hours till I found the repositories with the right binaries that made the tests pass.

The configuration is also testing with Java 8, and with Java 9. You may want to disable Java 9 if you have no plans to support it in the near future. It may be useful merely as an indicative of how hard it would be to get users with Java 9 in the future to run Cantaloupe.

At the very bottom, I left commented a [Coveralls](https://coveralls.io/) test coverage example. I think right now running the tests will be more useful than actually keeping track of the coverage, but in case you find it useful :-)

I had to try and test a few different configurations, but you can see the latest commit tested here: https://travis-ci.org/kinow/cantaloupe

If you would like to troubleshoot locally, the easiest way I found was to run:

```
$ docker run -it ubuntu:14.04 /bin/bash
$ apt-get update && apt-get upgrade
$ # install wget, git, maven, openjdk-8-jdk, checkout the project and then test it
```

Thanks!
Bruno