### PR TITLE
Fix dependencies with Maven Enforcer Plug-in

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,12 +59,22 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.1.8</version>
+      <version>1.2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <version>1.2.3</version>
     </dependency>
     <!-- Used by AmazonS3Resolver and AmazonS3Cache -->
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
+      <version>1.11.116</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
       <version>1.11.116</version>
     </dependency>
     <!-- Object cache used for caching delegate script method invocations
@@ -130,6 +140,23 @@
       <artifactId>commons-io</artifactId>
       <version>2.4</version>
     </dependency>
+    <!-- ImageIO -->
+    <dependency>
+      <groupId>javax.media</groupId>
+      <artifactId>jai-core</artifactId>
+      <version>1.1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.media</groupId>
+      <artifactId>jai_imageio</artifactId>
+      <version>1.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.media</groupId>
+          <artifactId>jai_core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <!-- Provides an ImageIO plugin for DICOM -->
     <dependency>
       <groupId>dcm4che</groupId>
@@ -166,7 +193,17 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.4</version>
+      <version>3.6</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.10</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.velocity</groupId>
+      <artifactId>velocity</artifactId>
+      <version>1.7</version>
     </dependency>
     <!-- Provides PDFBox for PdfBoxProcessor. Note that there are also some
     other dependencies in this POM used only by PDFBox. -->
@@ -184,9 +221,13 @@
     <!-- Assists in parsing XMP metadata in RDF/XML -->
     <dependency>
       <groupId>org.apache.jena</groupId>
-      <artifactId>apache-jena-libs</artifactId>
-      <type>pom</type>
-      <version>3.1.0</version>
+      <artifactId>jena-core</artifactId>
+      <version>3.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-arq</artifactId>
+      <version>3.4.0</version>
     </dependency>
     <!-- Used for media type detection -->
     <dependency>
@@ -238,6 +279,21 @@
     <!-- Used by HttpResolver -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-http</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-io</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-client</artifactId>
       <version>${jetty.version}</version>
     </dependency>
@@ -266,15 +322,30 @@
     <!-- Used to execute delegate script methods -->
     <dependency>
       <groupId>org.jruby</groupId>
-      <artifactId>jruby</artifactId>
+      <artifactId>jruby-core</artifactId>
       <version>9.1.10.0</version>
-      <type>pom</type>
     </dependency>
     <!-- Restlet is our REST framework. -->
     <dependency>
       <groupId>org.restlet.jee</groupId>
       <artifactId>org.restlet</artifactId>
       <version>${restlet.version}</version>
+    </dependency>
+    <!-- Jackson for data serialization -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.0</version>
     </dependency>
     <!-- Makes Restlet log to SLF4J -->
     <dependency>
@@ -336,6 +407,12 @@
   </dependencies>
 
   <repositories>
+    <!-- Provides JAI (javax.media and com.sun) -->
+    <repository>
+      <id>jboss-repository</id>
+      <name>JBoss Repository</name>
+      <url>https://repository.jboss.org/</url>
+    </repository>
     <!-- Provides the DICOM ImageIO plugin -->
     <repository>
       <id>www.dcm4che.org</id>
@@ -522,6 +599,43 @@
         <configuration>
           <mainClass>edu.illinois.library.cantaloupe.StandaloneEntry</mainClass>
         </configuration>
+      </plugin>
+
+      <!-- Build dependency check -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.3.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>de.is24.maven.enforcer.rules</groupId>
+            <artifactId>illegal-transitive-dependency-check</artifactId>
+            <version>1.7.4</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <illegalTransitiveDependencyCheck implementation="de.is24.maven.enforcer.rules.IllegalTransitiveDependencyCheck">
+                  <reportOnly>false</reportOnly>
+                  <useClassesFromLastBuild>true</useClassesFromLastBuild>
+                  <suppressTypesFromJavaRuntime>true</suppressTypesFromJavaRuntime>
+                  <!-- to ignore certain packages...
+                  <regexIgnoredClasses>
+                    <regexIgnoredClass>javax\..+</regexIgnoredClass>
+                  </regexIgnoredClasses>
+                   -->
+                </illegalTransitiveDependencyCheck>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,13 @@
       <artifactId>jruby-core</artifactId>
       <version>9.1.10.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.jruby</groupId>
+      <artifactId>jruby-stdlib</artifactId>
+      <version>9.1.10.0</version>
+      <!-- without jruby-stdib, tests won't pass. This is not necessary for compile-time though -->
+      <scope>runtime</scope>
+    </dependency>
     <!-- Restlet is our REST framework. -->
     <dependency>
       <groupId>org.restlet.jee</groupId>

--- a/src/main/java/edu/illinois/library/cantaloupe/cache/AmazonS3Cache.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/cache/AmazonS3Cache.java
@@ -16,7 +16,7 @@ import edu.illinois.library.cantaloupe.operation.OperationList;
 import edu.illinois.library.cantaloupe.image.Info;
 import edu.illinois.library.cantaloupe.util.AWSClientFactory;
 import edu.illinois.library.cantaloupe.util.Stopwatch;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/edu/illinois/library/cantaloupe/cache/AzureStorageCache.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/cache/AzureStorageCache.java
@@ -16,7 +16,7 @@ import edu.illinois.library.cantaloupe.image.Info;
 import edu.illinois.library.cantaloupe.operation.OperationList;
 import edu.illinois.library.cantaloupe.util.Stopwatch;
 import org.apache.commons.io.output.NullOutputStream;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
This PR introduces the [Maven Enforcer Plugin](http://maven.apache.org/enforcer/maven-enforcer-plugin/) to the `verify` phase of the project build lifecycle.

And it utilises a plug-in that makes sure we do not use transitive dependencies. It means that if we have dependencies like `commons-collections` (which includes `commons-lang` version 2.x) and `commons-lang3`, in case we use `StringUtils` from `commons-lang` 2.x, the build will fail. As `commons-lang` 2.x is a transitive dependency.

When running `mvn verify -DskipTests=true`, I initially got the following errors:

```
[WARNING] Rule 0: de.is24.maven.enforcer.rules.IllegalTransitiveDependencyCheck failed with message:
Found 53 illegal transitive type dependencies in artifact 'edu.illinois.library.cantaloupe:Cantaloupe:war:3.4-SNAPSHOT':
1.) ch.qos.logback.core.Context
2.) ch.qos.logback.core.filter.Filter
3.) ch.qos.logback.core.spi.FilterReply
4.) ch.qos.logback.core.util.StatusPrinter
5.) com.amazonaws.ClientConfiguration
6.) com.amazonaws.auth.AWSCredentials
7.) com.amazonaws.auth.AWSCredentialsProvider
8.) com.amazonaws.auth.AWSCredentialsProviderChain
9.) com.amazonaws.auth.EnvironmentVariableCredentialsProvider
10.) com.amazonaws.auth.InstanceProfileCredentialsProvider
11.) com.amazonaws.auth.SystemPropertiesCredentialsProvider
12.) com.amazonaws.auth.profile.ProfileCredentialsProvider
13.) com.amazonaws.client.builder.AwsClientBuilder
14.) com.fasterxml.jackson.annotation.JsonIgnore
15.) com.fasterxml.jackson.annotation.JsonInclude
16.) com.fasterxml.jackson.annotation.JsonInclude$Include
17.) com.fasterxml.jackson.annotation.JsonProperty
18.) com.fasterxml.jackson.annotation.JsonPropertyOrder
19.) com.fasterxml.jackson.core.JsonProcessingException
20.) com.fasterxml.jackson.databind.ObjectMapper
21.) com.fasterxml.jackson.databind.ObjectWriter
22.) com.fasterxml.jackson.databind.SerializationFeature
23.) com.sun.media.imageio.plugins.tiff.TIFFDirectory
24.) com.sun.media.imageio.plugins.tiff.TIFFField
25.) javax.media.jai.Interpolation
26.) javax.media.jai.JAI
27.) javax.media.jai.LookupTableJAI
28.) javax.media.jai.OpImage
29.) javax.media.jai.PlanarImage
30.) javax.media.jai.ROIShape
31.) javax.media.jai.RenderedOp
32.) javax.media.jai.operator.TransposeType
33.) org.apache.commons.codec.binary.Hex
34.) org.apache.commons.codec.digest.DigestUtils
35.) org.apache.commons.lang.StringUtils
36.) org.apache.jena.rdf.model.Literal
37.) org.apache.jena.rdf.model.Model
38.) org.apache.jena.rdf.model.ModelFactory
39.) org.apache.jena.rdf.model.NodeIterator
40.) org.apache.jena.rdf.model.Property
41.) org.apache.jena.rdf.model.RDFNode
42.) org.apache.jena.riot.RIOT
43.) org.apache.jena.riot.RiotException
44.) org.apache.velocity.app.Velocity
45.) org.apache.velocity.runtime.RuntimeServices
46.) org.apache.velocity.runtime.log.LogChute
47.) org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader
48.) org.eclipse.jetty.http.HttpField
49.) org.eclipse.jetty.http.HttpFields
50.) org.eclipse.jetty.http.HttpMethod
51.) org.eclipse.jetty.io.EofException
52.) org.eclipse.jetty.util.ssl.SslContextFactory
53.) org.jruby.RubyHash
```

These 53 classes are currently used in the project, but they are available through transitive dependencies. In most cases it will build fine, but we could be either using the wrong class (the example above, for StringUtils from `commons-lang` 2.x actually exists in the project) or have a problem later on, when we added another version with a different transitive dependency version.

The PR also includes fixes for all the 53 cases. For each case, I simply looked in Eclipse which `jar` contained the class, then looked up in http://search.maven.org. Had a bit of problem with `jai_core` classes, as the `jar` doesn't seem to be available in Maven Central, but only pom and javadoc.

Also updated Commons Lang, Jena, and LogBack, that are dependencies that I use in other projects and am a bit familiar with.

Cheers
Bruno