### PR TITLE
[WIP] Add performance benchmark tests with JMH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,10 +214,24 @@
       <artifactId>pdfbox</artifactId>
       <version>2.0.4</version>
     </dependency>
+    <!-- Unit tests -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Performance tests -->
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>1.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>1.19</version>
       <scope>test</scope>
     </dependency>
     <!-- Assists in parsing XMP metadata in RDF/XML -->
@@ -723,6 +737,53 @@
                 <exclude>Redis*Test</exclude>
               </excludes>
             </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>benchmark</id>
+      <properties>
+        <skipTests>true</skipTests>
+        <benchmark>edu.illinois</benchmark>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <testIncludes>
+                <testInclude>**/*</testInclude>
+              </testIncludes>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>benchmark</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <classpathScope>test</classpathScope>
+                  <executable>java</executable>
+                  <arguments>
+                    <argument>-classpath</argument>
+                    <classpath/>
+                    <argument>org.openjdk.jmh.Main</argument>
+                    <argument>-rf</argument>
+                    <argument>json</argument>
+                    <argument>-rff</argument>
+                    <argument>target/jmh-result.${benchmark}.json</argument>
+                    <argument>${benchmark}</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/src/test/java/edu/illinois/library/cantaloupe/perf/TIFFImageReaderPerformance.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/perf/TIFFImageReaderPerformance.java
@@ -1,0 +1,54 @@
+package edu.illinois.library.cantaloupe.perf;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import edu.illinois.library.cantaloupe.processor.imageio.TIFFImageReaderTest;
+
+/**
+ * Executes benchmark to compare the speed of reading TIFF files.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgs = { "-server", "-Xms128M", "-Xmx128M", "-Dcantaloupe.config=memory" })
+public class TIFFImageReaderPerformance extends TIFFImageReaderTest {
+
+    @Setup
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @TearDown
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Benchmark
+    public void testGetCompression() throws Exception {
+        super.testGetCompression();
+    }
+
+    @Benchmark
+    public void testGetMetadata() throws Exception {
+        super.testGetMetadata();
+    }
+
+    @Benchmark
+    public void testReadWithMonoResolutionImageAndNoScaleFactor() throws Exception {
+        super.testReadWithMonoResolutionImageAndNoScaleFactor();
+    }
+}

--- a/src/test/java/edu/illinois/library/cantaloupe/perf/TIFFImageWriterPerformance.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/perf/TIFFImageWriterPerformance.java
@@ -1,0 +1,67 @@
+package edu.illinois.library.cantaloupe.perf;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import edu.illinois.library.cantaloupe.processor.imageio.TIFFImageWriterTest;
+
+/**
+ * Executes benchmark to compare the speed of writing TIFF files.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgs = { "-server", "-Xms128M", "-Xmx128M", "-Dcantaloupe.config=memory" })
+public class TIFFImageWriterPerformance extends TIFFImageWriterTest {
+
+    @Benchmark
+    public void testWriteWithBufferedImage() throws Exception {
+        super.testWriteWithBufferedImage();
+    }
+
+    @Benchmark
+    public void testWriteWithBufferedImageAndExifMetadata() throws Exception {
+        super.testWriteWithBufferedImageAndExifMetadata();
+    }
+
+    @Benchmark
+    public void testWriteWithBufferedImageAndIptcMetadata() throws Exception {
+        super.testWriteWithBufferedImageAndIptcMetadata();
+    }
+
+    @Benchmark
+    public void testWriteWithBufferedImageAndXmpMetadata() throws Exception {
+        super.testWriteWithBufferedImageAndXmpMetadata();
+    }
+
+    @Benchmark
+    public void testWriteWithPlanarImage() throws Exception {
+        super.testWriteWithPlanarImage();
+    }
+
+    @Benchmark
+    public void testWriteWithPlanarImageAndExifMetadata() throws Exception {
+        super.testWriteWithPlanarImageAndExifMetadata();
+    }
+
+    @Benchmark
+    public void testWriteWithPlanarImageAndIptcMetadata() throws Exception {
+        super.testWriteWithPlanarImageAndIptcMetadata();
+    }
+
+    @Benchmark
+    public void testWriteWithPlanarImageAndXmpMetadata() throws Exception {
+        super.testWriteWithPlanarImageAndXmpMetadata();
+    }
+}

--- a/src/test/java/edu/illinois/library/cantaloupe/perf/package-info.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/perf/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Tests for performance benchmarking. These tests are not normally executed with the build process. But can be
+ * triggered for comparing different versions of Cantaloupe. They are written in normal JUnit style, but executed
+ * with <a href="http://openjdk.java.net/projects/code-tools/jmh/">JMH</a>, a Java benchmark test framework.
+ */
+package edu.illinois.library.cantaloupe.perf;


### PR DESCRIPTION
This is related to #140. It is not as comprehensive as suggested in the issue. But this pull request contains an example of microbenchmarking with [JMH](http://openjdk.java.net/projects/code-tools/jmh/).

The two benchmark tests included simply extend existing TIFF reader/write tests. Ideally, I think we would like to map a few operations that are considered important and worth keeping an eye every now and then.

Users & developers are then able to run the test in their environment and compare with other results by other users.

This can be useful when choosing hardware for a Cantaloupe server, investigating slowness, and checking for regressions in the code (i.e. run the JMH tests against tag 1.0, and later compare with results from tag 2.0 and see what was the difference).

It is possible to run these tests in Travis CI too, though it requires further investigation if worth, as it may take a while - I suspect running occasionally before releases with important changes should suffice.

Running the tests:

```
$ mvn clean test -Pbenchmark
# the test is just the phase. The normal tests are being ignored, see the profile settings for more
# and it may take several minutes depending on hardware and tests
# then eventually you get something like...
# Run complete. Total time: 00:01:54

Benchmark                                                                   Mode  Cnt     Score     Error  Units
TIFFImageReaderPerformance.testGetCompression                               avgt    5  3478.766 ± 386.671  us/op
TIFFImageReaderPerformance.testGetMetadata                                  avgt    5   384.149 ±  32.546  us/op
TIFFImageReaderPerformance.testReadWithMonoResolutionImageAndNoScaleFactor  avgt    5   331.710 ±  21.164  us/op
TIFFImageWriterPerformance.testWriteWithBufferedImage                       avgt    5  1287.574 ± 123.852  us/op
TIFFImageWriterPerformance.testWriteWithBufferedImageAndExifMetadata        avgt    5  2486.737 ± 295.360  us/op
TIFFImageWriterPerformance.testWriteWithBufferedImageAndIptcMetadata        avgt    5  2657.941 ± 270.055  us/op
TIFFImageWriterPerformance.testWriteWithBufferedImageAndXmpMetadata         avgt    5  2421.456 ± 297.486  us/op
TIFFImageWriterPerformance.testWriteWithPlanarImage                         avgt    5  1389.420 ±  99.007  us/op
TIFFImageWriterPerformance.testWriteWithPlanarImageAndExifMetadata          avgt    5  2553.279 ± 335.514  us/op
TIFFImageWriterPerformance.testWriteWithPlanarImageAndIptcMetadata          avgt    5  2323.278 ± 134.614  us/op
TIFFImageWriterPerformance.testWriteWithPlanarImageAndXmpMetadata           avgt    5  2346.666 ± 215.869  us/op

Benchmark result is saved to target/jmh-result.edu.illinois.json
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:02 min
[INFO] Finished at: 2017-08-18T14:44:29+12:00
[INFO] Final Memory: 37M/402M
[INFO] ------------------------------------------------------------------------
```

In this case the output is in [average time](http://hg.openjdk.java.net/code-tools/jmh/file/6cc1450c6a0f/jmh-core/src/main/java/org/openjdk/jmh/results/AverageTimeResult.java#l39). So the `testGetCompression` was executed 5 times, and the average time was 3478.766 micro-seconds (3.4 milliseconds, under 0.004 seconds :-)).

Marking as DISCUSSION as it would require a confirmation it is desirable to have it in the project. I read the comment in #140, and I agree about the scope if the tests are supposed to guarantee backward compatibility, compatibility with other tools, etc. But these tests would be simply for micro benchmarking. In other words, we could use it if someone suggested that in the current release, a certain operation has degraded in performance.

And it is also for DISCUSSION because the current examples are simply to illustrate how it could be implemented. I agree with original request in #140 that we would want to have some good input files, and also specific operations that are considered important.

Example of projects using JMH, from where I adapted the configuration for Cantaloupe:

* [Apache Commons CSV](https://github.com/apache/commons-csv/blob/431f8236e89acd1bd3c678fad727f2d585226be8/pom.xml#L398)
* [Apache Commons RNG (random number generator)](https://github.com/apache/commons-rng/tree/b8fa4766c710d9e57fb866180dd17180d192bb70/commons-rng-jmh)

Cheers
Bruno