### PR TITLE
Remove unnecessary duplicated dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,22 +357,6 @@
       <artifactId>jackson-databind</artifactId>
       <version>2.9.0</version>
     </dependency>
-    <!-- Jackson for data serialization -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>2.9.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <version>2.9.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.9.0</version>
-    </dependency>
     <!-- Makes Restlet log to SLF4J -->
     <dependency>
       <groupId>org.restlet.jee</groupId>


### PR DESCRIPTION
Noticed a new warning when running the tests, then tried the `validate` goal to confirm what was wrong.

```
$ mvn validate
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for edu.illinois.library.cantaloupe:Cantaloupe:war:3.4-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: com.fasterxml.jackson.core:jackson-core:jar -> duplicate declaration of version 2.9.0 @ line 361, column 17
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: com.fasterxml.jackson.core:jackson-annotations:jar -> duplicate declaration of version 2.9.0 @ line 366, column 17
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: com.fasterxml.jackson.core:jackson-databind:jar -> duplicate declaration of version 2.9.0 @ line 371, column 17
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building Cantaloupe 3.4-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.279 s
[INFO] Finished at: 2017-08-18T15:13:51+12:00
[INFO] Final Memory: 8M/159M
[INFO] ------------------------------------------------------------------------
```

This pull request simply removes the duplicates. All tests (1301, in the `freedeps` profile) passing.