### PR TITLE
Make improvements to the IIIF sizes metadata

### DIFF
--- a/cantaloupe.properties.sample
+++ b/cantaloupe.properties.sample
@@ -90,6 +90,9 @@ endpoint.iiif.2.enabled = true
 # using the ?response-content-disposition query argument.
 endpoint.iiif.content_disposition = none
 
+# Minimum size that will be used in info.json "sizes" keys.
+endpoint.iiif.min_size = 64
+
 # Minimum size that will be used in info.json "tiles" keys. See the user
 # manual for an explanation of how these are calculated.
 endpoint.iiif.min_tile_size = 1024

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jetty.version>9.4.6.v20170531</jetty.version>
     <restlet.version>2.3.10</restlet.version>
+    <surefire.version>2.20.1</surefire.version>
   </properties>
 
   <developers>
@@ -453,7 +454,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>${surefire.version}</version>
         <configuration>
           <runOrder>random</runOrder>
           <reuseForks>false</reuseForks>
@@ -565,7 +566,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>create-war</id>
@@ -584,12 +585,22 @@
             </configuration>
           </execution>
         </executions>
+        <!-- This plugin depends on a version of plexus-archiver that
+        doesn't work with JDK 9. So, use a version that does.
+        TODO: revisit this -->
+        <dependencies>
+          <dependency>
+             <groupId>org.codehaus.plexus</groupId>
+             <artifactId>plexus-archiver</artifactId>
+             <version>3.5</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
       <!-- Assemble the created war into a release package. -->
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.5.5</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -604,6 +615,16 @@
             <descriptor>${basedir}/build/assembly.xml</descriptor>
           </descriptors>
         </configuration>
+        <!-- This plugin depends on a version of plexus-archiver that
+        doesn't work with JDK 9. So, use a version that does.
+        TODO: revisit this -->
+        <dependencies>
+          <dependency>
+             <groupId>org.codehaus.plexus</groupId>
+             <artifactId>plexus-archiver</artifactId>
+             <version>3.5</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
       <!-- Enables running with mvn exec:java -->
@@ -667,7 +688,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.19.1</version>
+            <version>${surefire.version}</version>
             <configuration>
               <runOrder>random</runOrder>
               <reuseForks>false</reuseForks>
@@ -696,7 +717,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>2.19.1</version>
+            <version>${surefire.version}</version>
             <configuration>
               <runOrder>random</runOrder>
               <reuseForks>false</reuseForks>

--- a/pom.xml
+++ b/pom.xml
@@ -461,6 +461,13 @@
         </configuration>
       </plugin>
 
+      <!-- Find bugs with mvn findbugs:findbugs findbugs:gui -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>3.0.1</version>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/java/edu/illinois/library/cantaloupe/RestletApplication.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/RestletApplication.java
@@ -8,8 +8,8 @@ import edu.illinois.library.cantaloupe.processor.UnsupportedOutputFormatExceptio
 import edu.illinois.library.cantaloupe.resource.AbstractResource;
 import edu.illinois.library.cantaloupe.resource.LandingResource;
 import edu.illinois.library.cantaloupe.resource.admin.AdminResource;
+import edu.illinois.library.cantaloupe.resource.admin.ConfigurationResource;
 import edu.illinois.library.cantaloupe.resource.api.CacheResource;
-import edu.illinois.library.cantaloupe.resource.api.ConfigurationResource;
 import edu.illinois.library.cantaloupe.resource.api.DMICResource;
 import org.restlet.Application;
 import org.restlet.Request;
@@ -111,6 +111,7 @@ public class RestletApplication extends Application {
     }
 
     public static final String ADMIN_PATH = "/admin";
+    public static final String ADMIN_CONFIG_PATH = "/admin/configuration";
     public static final String CACHE_PATH = "/cache";
     public static final String CONFIGURATION_PATH = "/configuration";
     public static final String DELEGATE_METHOD_INVOCATION_CACHE_PATH = "/dmic";
@@ -267,12 +268,16 @@ public class RestletApplication extends Application {
                 Redirector.MODE_CLIENT_SEE_OTHER);
         router.attach(IIIF_PATH, redirector);
 
-        /****************** Admin route ********************/
+        /****************** Admin routes ********************/
 
         try {
             ChallengeAuthenticator adminAuth = createAdminAuthenticator();
             adminAuth.setNext(AdminResource.class);
             router.attach(ADMIN_PATH, adminAuth);
+
+            adminAuth = createAdminAuthenticator();
+            adminAuth.setNext(ConfigurationResource.class);
+            router.attach(ADMIN_CONFIG_PATH, adminAuth);
         } catch (ConfigurationException e) {
             getLogger().log(Level.INFO, e.getMessage());
         }

--- a/src/main/java/edu/illinois/library/cantaloupe/cache/FilesystemCache.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/cache/FilesystemCache.java
@@ -213,13 +213,14 @@ class FilesystemCache implements SourceCache, DerivativeCache {
             this.toRemove = toRemove;
         }
 
+        /**
+         * N.B.: This implementation can cope with being called multiple times,
+         * which is important. See inline doc in
+         * {@link edu.illinois.library.cantaloupe.resource.ImageRepresentation#write}
+         * for more info.
+         */
         @Override
         public void close() throws IOException {
-            // This check prevents double-closing. Clients will frequently wrap
-            // this stream in a TeeOutputStream, which they can't close due to
-            // Restlet's OutputRepresentation.write() API contract, so it (the
-            // tee stream) gets detected and double-closed by the finalizer.
-            // See ImageRepresentation.write() for more info.
             if (!isClosed) {
                 isClosed = true;
                 try {
@@ -276,8 +277,7 @@ class FilesystemCache implements SourceCache, DerivativeCache {
 
     // Algorithm used for hashing identifiers to create filenames & pathnames.
     // Will be passed to MessageDigest.getInstance(). MD5 is chosen for its
-    // practical combination of efficiency and collision resistance.
-    // N.B. filenameSafe() must be updated when changing this.
+    // efficiency. A collision here and there is not a big deal.
     private static final String HASH_ALGORITHM = "MD5";
     private static final String SOURCE_IMAGE_FOLDER = "source";
     private static final String DERIVATIVE_IMAGE_FOLDER = "image";
@@ -395,7 +395,6 @@ class FilesystemCache implements SourceCache, DerivativeCache {
     /**
      * @return Pathname of the derivative image cache folder, or null if
      *         {@link Key#FILESYSTEMCACHE_PATHNAME} is not set.
-     * @throws CacheException
      */
     static String rootDerivativeImagePathname() throws CacheException {
         return rootPathname() + File.separator + DERIVATIVE_IMAGE_FOLDER;
@@ -404,7 +403,6 @@ class FilesystemCache implements SourceCache, DerivativeCache {
     /**
      * @return Pathname of the image info cache folder, or null if
      *         {@link Key#FILESYSTEMCACHE_PATHNAME} is not set.
-     * @throws CacheException
      */
     static String rootInfoPathname() throws CacheException {
         return rootPathname() + File.separator + INFO_FOLDER;
@@ -414,7 +412,6 @@ class FilesystemCache implements SourceCache, DerivativeCache {
      * @return Pathname of the source image cache folder, or null if
      *         {@link Key#FILESYSTEMCACHE_PATHNAME}
      *         is not set.
-     * @throws CacheException
      */
     static String rootSourceImagePathname() throws CacheException {
         return rootPathname() + File.separator + SOURCE_IMAGE_FOLDER;
@@ -431,8 +428,6 @@ class FilesystemCache implements SourceCache, DerivativeCache {
 
     /**
      * Cleans up temp and zero-byte files.
-     *
-     * @throws CacheException
      */
     @Override
     public void cleanUp() throws CacheException {
@@ -472,7 +467,6 @@ class FilesystemCache implements SourceCache, DerivativeCache {
      * @param identifier
      * @return All image files deriving from the image with the given
      *         identifier.
-     * @throws CacheException
      */
     Collection<File> derivativeImageFiles(Identifier identifier)
             throws CacheException {
@@ -705,8 +699,6 @@ class FilesystemCache implements SourceCache, DerivativeCache {
      *
      * <p>Will do nothing and return immediately if a global purge is in
      * progress in another thread.</p>
-     *
-     * @throws CacheException
      */
     @Override
     public void purge() throws CacheException {
@@ -757,8 +749,6 @@ class FilesystemCache implements SourceCache, DerivativeCache {
      *
      * <p>Will do nothing and return immediately if a global purge is in
      * progress in another thread.</p>
-     *
-     * @throws CacheException
      */
     @Override
     public void purge(OperationList opList) throws CacheException {
@@ -803,8 +793,6 @@ class FilesystemCache implements SourceCache, DerivativeCache {
      *
      * <p>Will do nothing and return immediately if a global purge is in
      * progress in another thread.</p>
-     *
-     * @throws CacheException
      */
     @Override
     public void purgeExpired() throws CacheException {
@@ -873,8 +861,6 @@ class FilesystemCache implements SourceCache, DerivativeCache {
      *
      * <p>Will do nothing and return immediately if a global purge is in
      * progress in another thread.</p>
-     *
-     * @throws CacheException
      */
     @Override
     public void purge(Identifier identifier) throws CacheException {

--- a/src/main/java/edu/illinois/library/cantaloupe/config/Key.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/config/Key.java
@@ -127,6 +127,7 @@ public enum Key {
     IIIF_2_ENDPOINT_ENABLED("endpoint.iiif.2.enabled"),
     IIIF_2_RESTRICT_TO_SIZES("endpoint.iiif.2.restrict_to_sizes"),
     IIIF_CONTENT_DISPOSITION("endpoint.iiif.content_disposition"),
+    IIIF_MIN_SIZE("endpoint.iiif.min_size"),
     IIIF_MIN_TILE_SIZE("endpoint.iiif.min_tile_size"),
     IMAGEMAGICKPROCESSOR_PATH_TO_BINARIES("ImageMagickProcessor.path_to_binaries"),
     JDBCCACHE_CONNECTION_TIMEOUT("JdbcCache.connection_timeout"),

--- a/src/main/java/edu/illinois/library/cantaloupe/operation/Rotate.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/operation/Rotate.java
@@ -71,12 +71,14 @@ public class Rotate implements Operation {
      */
     @Override
     public Dimension getResultingSize(Dimension fullSize) {
+        final double radians = Math.toRadians(getDegrees());
+        final double sin = Math.sin(radians);
+        final double cos = Math.cos(radians);
+
         final int width = (int) Math.round(
-                Math.abs(fullSize.width * Math.cos(this.getDegrees())) +
-                        Math.abs(fullSize.height * Math.sin(this.getDegrees())));
+                Math.abs(fullSize.width * cos) + Math.abs(fullSize.height * sin));
         final int height = (int) Math.round(
-                Math.abs(fullSize.height * Math.cos(this.getDegrees())) +
-                        Math.abs(fullSize.width * Math.sin(this.getDegrees())));
+                Math.abs(fullSize.height * cos) + Math.abs(fullSize.width * sin));
         return new Dimension(width, height);
     }
 

--- a/src/main/java/edu/illinois/library/cantaloupe/processor/GraphicsMagickProcessor.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/GraphicsMagickProcessor.java
@@ -111,9 +111,9 @@ class GraphicsMagickProcessor extends AbstractMagickProcessor
                 LOGGER.info("getFormats(): invoking {}", commandString);
                 final Process process = pb.start();
 
-                try (final InputStream processInputStream = process.getInputStream()) {
-                    BufferedReader stdInput = new BufferedReader(
-                            new InputStreamReader(processInputStream));
+                final InputStream processInputStream = process.getInputStream();
+                try (BufferedReader stdInput = new BufferedReader(
+                        new InputStreamReader(processInputStream))) {
                     String s;
                     boolean read = false;
                     while ((s = stdInput.readLine()) != null) {

--- a/src/main/java/edu/illinois/library/cantaloupe/processor/package-info.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/processor/package-info.java
@@ -6,8 +6,8 @@
  * {@link edu.illinois.library.cantaloupe.operation.Operation operations} from
  * an {@link edu.illinois.library.cantaloupe.operation.OperationList} in
  * order, and writes the result to an {@link java.io.OutputStream}. In this way
- * it is more-or-less source- and output-agnostic (it doesn't care where the
- * source image is coming from or going to)</p>
+ * it is source- and output-agnostic (it doesn't care where the source image is
+ * coming from or going to).</p>
  *
  * <h3>Reading from files vs. streams</h3>
  *
@@ -36,9 +36,8 @@
  * processor.</p>
  *
  * <p>Format availability (or "awareness") is governed by the
- * {@link edu.illinois.library.cantaloupe.image.Format} enum. If this does not
- * already contain the formats a processor wishes to support, it will need to
- * be added.</p>
+ * {@link edu.illinois.library.cantaloupe.image.Format} enum. If a processor
+ * wishes to support a format not contained therein, it must be added.</p>
  *
  * <h3>Other means of adding format support</h3>
  *
@@ -46,10 +45,9 @@
  * application. However, note that the {@link javax.imageio.ImageIO} framework
  * used by {@link edu.illinois.library.cantaloupe.processor.Java2dProcessor}
  * and {@link edu.illinois.library.cantaloupe.processor.JaiProcessor} supports
- * format plugins, which are automatically available in these processors.
+ * format plugins, which are trivial to make available in these processors.
  * ImageIO also supports image access via an
  * {@link javax.imageio.stream.ImageInputStream ImageInputStream}, which can
- * offer major efficiency advantages. Finally, being Java, an ImageIO plugin
- * can be bundled in so there are no external dependencies.</p>
+ * offer major efficiency advantages.</p>
  */
 package edu.illinois.library.cantaloupe.processor;

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/admin/AbstractResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/admin/AbstractResource.java
@@ -1,0 +1,21 @@
+package edu.illinois.library.cantaloupe.resource.admin;
+
+import edu.illinois.library.cantaloupe.config.Configuration;
+import edu.illinois.library.cantaloupe.resource.EndpointDisabledException;
+import org.restlet.resource.ResourceException;
+
+abstract class AbstractResource extends
+        edu.illinois.library.cantaloupe.resource.AbstractResource {
+
+    static final String CONTROL_PANEL_ENABLED_CONFIG_KEY = "admin.enabled";
+
+    @Override
+    protected void doInit() throws ResourceException {
+        if (!Configuration.getInstance().getBoolean(
+                CONTROL_PANEL_ENABLED_CONFIG_KEY, false)) {
+            throw new EndpointDisabledException();
+        }
+        super.doInit();
+    }
+
+}

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/admin/ConfigurationResource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/admin/ConfigurationResource.java
@@ -1,0 +1,74 @@
+package edu.illinois.library.cantaloupe.resource.admin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.illinois.library.cantaloupe.config.Configuration;
+import edu.illinois.library.cantaloupe.resource.JSONRepresentation;
+import org.restlet.representation.EmptyRepresentation;
+import org.restlet.representation.Representation;
+import org.restlet.resource.Get;
+import org.restlet.resource.Put;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Resource for retrieving and updating the application configuration object
+ * via XHR in the Control Panel.
+ */
+public class ConfigurationResource extends AbstractResource {
+
+    private static final Logger LOGGER = LoggerFactory.
+            getLogger(ConfigurationResource.class);
+
+    /**
+     * @return JSON application configuration. <strong>This may contain
+     *         sensitive info and must be protected.</strong>
+     */
+    @Get("json")
+    public Representation doGet() throws Exception {
+        return new JSONRepresentation(configurationAsMap());
+    }
+
+    /**
+     * Deserializes submitted JSON data and updates the application
+     * configuration instance with it.
+     */
+    @Put("json")
+    public Representation doPut(Representation rep) throws IOException {
+        final Configuration config = Configuration.getInstance();
+        final Map submittedConfig = new ObjectMapper().readValue(
+                rep.getStream(), HashMap.class);
+
+        // Copy configuration keys and values from the request JSON payload to
+        // the application configuration.
+        for (final Object key : submittedConfig.keySet()) {
+            final Object value = submittedConfig.get(key);
+            LOGGER.debug("Setting {} = {}", key, value);
+            config.setProperty((String) key, value);
+        }
+
+        config.save();
+
+        return new EmptyRepresentation();
+    }
+
+    /**
+     * @return Map representation of the application configuration.
+     */
+    private Map<String,Object> configurationAsMap() {
+        final Configuration config = Configuration.getInstance();
+        final Map<String,Object> configMap = new HashMap<>();
+        final Iterator<String> it = config.getKeys();
+        while (it.hasNext()) {
+            final String key = it.next();
+            final Object value = config.getProperty(key);
+            configMap.put(key, value);
+        }
+        return configMap;
+    }
+
+}

--- a/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/ImageInfoFactory.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/resource/iiif/v2/ImageInfoFactory.java
@@ -30,9 +30,6 @@ class ImageInfoFactory {
     private static final Logger LOGGER = LoggerFactory.
             getLogger(ImageInfoFactory.class);
 
-    /** Minimum size that will be used in info.json "sizes" keys. */
-    private static final int MIN_SIZE = 64;
-
     /** Delegate script method that returns a JSON object (Ruby hash)
      * containing additional keys to add to the information response. */
     private static final String SERVICE_DELEGATE_METHOD =
@@ -74,12 +71,15 @@ class ImageInfoFactory {
         final List<ImageInfo.Size> sizes = new ArrayList<>();
         imageInfo.put("sizes", sizes);
 
+        /** Minimum size that will be used in info.json "sizes" keys. */
+        final int minSize = config.getInt(Key.IIIF_MIN_SIZE, 64);
+
         final int maxReductionFactor =
-                ImageInfoUtil.maxReductionFactor(virtualSize, MIN_SIZE);
-        for (double i = 2; i <= Math.pow(2, maxReductionFactor); i *= 2) {
+                ImageInfoUtil.maxReductionFactor(virtualSize, minSize);
+        for (double i = 1; i <= Math.pow(2, maxReductionFactor); i *= 2) {
             final int width = (int) Math.round(virtualSize.width / i);
             final int height = (int) Math.round(virtualSize.height / i);
-            if (width < MIN_SIZE || height < MIN_SIZE) {
+            if (width < minSize || height < minSize) {
                 break;
             }
             ImageInfo.Size size = new ImageInfo.Size(width, height);

--- a/src/main/resources/admin.vm
+++ b/src/main/resources/admin.vm
@@ -501,6 +501,20 @@
                                     </td>
                                 </tr>
                                 <tr>
+                                    <td>Minimum Size
+                                        <a tabindex="0" class="btn btn-sm cl-help"
+                                           role="button" data-toggle="popover"
+                                           data-trigger="focus"
+                                           data-content="Minimum size that will be used in info.json
+                                           &lt;code&gt;sizes&lt;/code&gt; keys.">?</a>
+                                    </td>
+                                    <td>
+                                        <input class="form-control" type="number"
+                                               name="endpoint.iiif.min_size" min="0"
+                                               data-requires-restart="false">
+                                    </td>
+                                </tr>
+                                <tr>
                                     <td>Minimum Tile Size
                                         <a tabindex="0" class="btn btn-sm cl-help"
                                            role="button" data-toggle="popover"

--- a/src/main/resources/public_html/scripts/admin.js
+++ b/src/main/resources/public_html/scripts/admin.js
@@ -6,8 +6,6 @@
  */
 var Configuration = function(data) {
 
-    var self = this;
-
     /**
      * @returns {*}
      */
@@ -46,6 +44,9 @@ var Configuration = function(data) {
     };
 
 };
+
+Configuration.ENDPOINT = window.location + '/configuration';
+
 
 /**
  * @param config {Configuration}
@@ -189,9 +190,9 @@ var Form = function(config) {
         console.debug(config.data());
 
         $.ajax({
-            type: 'POST',
+            type: 'PUT',
             contentType: 'application/json',
-            url: window.location,
+            url: Configuration.ENDPOINT,
             data: config.toJsonString(),
             success: function() {
                 // Set the success message, make it appear, and fade it out on
@@ -239,7 +240,7 @@ $(document).ready(function() {
     // initialize a Form instance on success.
     $.ajax({
         dataType: 'json',
-        url: window.location,
+        url: Configuration.ENDPOINT,
         data: null,
         success: function(data) {
             new Form(new Configuration(data)).load();

--- a/src/test/java/edu/illinois/library/cantaloupe/operation/RotateTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/operation/RotateTest.java
@@ -47,20 +47,14 @@ public class RotateTest extends BaseTest {
     }
 
     @Test
-    public void getEffectiveSize() {
+    public void getResultingSize() {
         Dimension fullSize = new Dimension(300, 200);
         assertEquals(fullSize, instance.getResultingSize(fullSize));
 
-        final int degrees = 45;
+        final int degrees = 30;
         instance.setDegrees(degrees);
 
-        final int expectedWidth = (int) Math.round(
-                Math.abs(fullSize.width * Math.cos(degrees)) +
-                        Math.abs(fullSize.height * Math.sin(degrees)));
-        final int expectedHeight = (int) Math.round(
-                Math.abs(fullSize.height * Math.cos(degrees)) +
-                        Math.abs(fullSize.width * Math.sin(degrees)));
-        Dimension expectedSize = new Dimension(expectedWidth, expectedHeight);
+        Dimension expectedSize = new Dimension(360, 323);
         assertEquals(expectedSize, instance.getResultingSize(fullSize));
     }
 

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/admin/AdminResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/admin/AdminResourceTest.java
@@ -1,6 +1,5 @@
 package edu.illinois.library.cantaloupe.resource.admin;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.illinois.library.cantaloupe.RestletApplication;
 import edu.illinois.library.cantaloupe.config.Configuration;
 import edu.illinois.library.cantaloupe.config.Key;
@@ -12,8 +11,6 @@ import org.restlet.data.ChallengeResponse;
 import org.restlet.data.ChallengeScheme;
 import org.restlet.data.MediaType;
 import org.restlet.data.Status;
-import org.restlet.representation.Representation;
-import org.restlet.representation.StringRepresentation;
 import org.restlet.resource.ClientResource;
 import org.restlet.resource.ResourceException;
 
@@ -73,7 +70,7 @@ public class AdminResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testDoGetAsHtml() throws Exception {
+    public void testDoGet() throws Exception {
         // no credentials
         ClientResource client = getClientForUriPath(RestletApplication.ADMIN_PATH);
         try {
@@ -103,45 +100,13 @@ public class AdminResourceTest extends ResourceTest {
     }
 
     @Test
-    public void testDoGetAsJson() {
-        Configuration.getInstance().setProperty("test", "cats");
-
-        ClientResource client = getClientForUriPath(RestletApplication.ADMIN_PATH,
-                USERNAME, SECRET);
-
-        client.get(MediaType.APPLICATION_JSON);
-        assertTrue(client.getResponse().getEntityAsText().
-                contains("\"test\":\"cats\""));
-    }
-
-    @Test
-    public void testDoPost() throws Exception {
-        Map<String,Object> entityMap = new HashMap<>();
-        entityMap.put("test", "cats");
-        String entityStr = new ObjectMapper().writer().writeValueAsString(entityMap);
-        Representation rep = new StringRepresentation(entityStr,
-                MediaType.APPLICATION_JSON);
-
-        ClientResource client = getClientForUriPath(
-                RestletApplication.ADMIN_PATH, USERNAME, SECRET);
-        client.post(rep);
-
-        assertEquals("cats", Configuration.getInstance().getString("test"));
-    }
-
-    @Test
-    public void testDoPostSavesFile() {
-        // TODO: write this
-    }
-
-    @Test
     public void testEnabled() {
         Configuration config = Configuration.getInstance();
         // enabled
         config.setProperty(Key.ADMIN_ENABLED, true);
 
-        ClientResource client = getClientForUriPath(RestletApplication.ADMIN_PATH,
-                USERNAME, SECRET);
+        ClientResource client = getClientForUriPath(
+                RestletApplication.ADMIN_PATH, USERNAME, SECRET);
         client.get();
         assertEquals(Status.SUCCESS_OK, client.getStatus());
 

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/admin/ConfigurationResourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/admin/ConfigurationResourceTest.java
@@ -1,0 +1,89 @@
+package edu.illinois.library.cantaloupe.resource.admin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.illinois.library.cantaloupe.RestletApplication;
+import edu.illinois.library.cantaloupe.config.Configuration;
+import edu.illinois.library.cantaloupe.config.Key;
+import edu.illinois.library.cantaloupe.resource.ResourceTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.restlet.Context;
+import org.restlet.Request;
+import org.restlet.Response;
+import org.restlet.data.MediaType;
+import org.restlet.data.Status;
+import org.restlet.representation.Representation;
+import org.restlet.representation.StringRepresentation;
+import org.restlet.resource.ClientResource;
+import org.restlet.resource.ResourceException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class ConfigurationResourceTest extends ResourceTest {
+
+    private static final String USERNAME = "admin";
+    private static final String SECRET = "secret";
+
+    private ConfigurationResource instance;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        final Configuration config = Configuration.getInstance();
+        config.setProperty(Key.ADMIN_SECRET, SECRET);
+
+        instance = new ConfigurationResource();
+        Request request = new Request();
+        instance.init(new Context(), request, new Response(request));
+    }
+
+    @Test
+    public void testDoGetAsJson() throws Exception {
+        Configuration.getInstance().setProperty("test", "cats");
+
+        Representation rep = instance.doGet();
+
+        assertTrue(rep.getText().contains("\"test\":\"cats\""));
+    }
+
+    @Test
+    public void testDoPut() throws Exception {
+        Map<String,Object> entityMap = new HashMap<>();
+        entityMap.put("test", "cats");
+        String entityStr = new ObjectMapper().writer().writeValueAsString(entityMap);
+        Representation rep = new StringRepresentation(
+                entityStr, MediaType.APPLICATION_JSON);
+
+        instance.doPut(rep);
+
+
+        assertEquals("cats", Configuration.getInstance().getString("test"));
+    }
+
+    @Test
+    public void testEnabled() throws Exception {
+        Configuration config = Configuration.getInstance();
+        // enabled
+        config.setProperty(AbstractResource.CONTROL_PANEL_ENABLED_CONFIG_KEY, true);
+
+        ClientResource client = getClientForUriPath(
+                RestletApplication.ADMIN_CONFIG_PATH, USERNAME, SECRET);
+        client.get();
+        assertEquals(Status.SUCCESS_OK, client.getStatus());
+
+        // disabled
+        config.setProperty(AbstractResource.CONTROL_PANEL_ENABLED_CONFIG_KEY, false);
+        try {
+            client.get();
+            fail("Expected exception");
+        } catch (ResourceException e) {
+            assertEquals(Status.CLIENT_ERROR_FORBIDDEN, client.getStatus());
+        }
+    }
+
+}

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/admin/ControlPanelTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/admin/ControlPanelTest.java
@@ -133,6 +133,7 @@ public class ControlPanelTest extends ResourceTest {
         inputNamed(Key.BASIC_AUTH_USERNAME).sendKeys("dogs");
         inputNamed(Key.BASIC_AUTH_SECRET).sendKeys("foxes");
         selectNamed(Key.IIIF_CONTENT_DISPOSITION).selectByValue("attachment");
+        inputNamed(Key.IIIF_MIN_SIZE).sendKeys("75");
         inputNamed(Key.IIIF_MIN_TILE_SIZE).sendKeys("250");
         inputNamed(Key.IIIF_1_ENDPOINT_ENABLED).click();
         inputNamed(Key.IIIF_2_ENDPOINT_ENABLED).click();
@@ -154,6 +155,7 @@ public class ControlPanelTest extends ResourceTest {
         assertEquals("foxes", config.getString(Key.BASIC_AUTH_SECRET));
         assertEquals("attachment",
                 config.getString(Key.IIIF_CONTENT_DISPOSITION));
+        assertEquals(75, config.getInt(Key.IIIF_MIN_SIZE));
         assertEquals(250, config.getInt(Key.IIIF_MIN_TILE_SIZE));
         assertTrue(config.getBoolean(Key.IIIF_1_ENDPOINT_ENABLED));
         assertTrue(config.getBoolean(Key.IIIF_2_ENDPOINT_ENABLED));

--- a/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/ImageInfoFactoryTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resource/iiif/v2/ImageInfoFactoryTest.java
@@ -98,13 +98,32 @@ public class ImageInfoFactoryTest extends BaseTest {
         @SuppressWarnings("unchecked")
         List<ImageInfo.Size> sizes =
                 (List<ImageInfo.Size>) imageInfo.get("sizes");
-        assertEquals(3, sizes.size());
+        assertEquals(4, sizes.size());
         assertEquals(74, (long) sizes.get(0).width);
         assertEquals(65, (long) sizes.get(0).height);
         assertEquals(149, (long) sizes.get(1).width);
         assertEquals(131, (long) sizes.get(1).height);
         assertEquals(297, (long) sizes.get(2).width);
         assertEquals(261, (long) sizes.get(2).height);
+        assertEquals(594, (long) sizes.get(3).width);
+        assertEquals(522, (long) sizes.get(3).height);
+    }
+
+    @Test
+    public void testNewImageInfoSizesMinSize() throws Exception {
+        Configuration config = Configuration.getInstance();
+        config.setProperty(Key.IIIF_MIN_SIZE, 200);
+
+        imageInfo = new ImageInfoFactory().newImageInfo(
+                identifier, imageUri, processor, processor.readImageInfo());
+        @SuppressWarnings("unchecked")
+        List<ImageInfo.Size> sizes =
+                (List<ImageInfo.Size>) imageInfo.get("sizes");
+        assertEquals(2, sizes.size());
+        assertEquals(297, (long) sizes.get(0).width);
+        assertEquals(261, (long) sizes.get(0).height);
+        assertEquals(594, (long) sizes.get(1).width);
+        assertEquals(522, (long) sizes.get(1).height);
     }
 
     @Test

--- a/website/changes.html
+++ b/website/changes.html
@@ -64,7 +64,8 @@ title: Change Log
 <ul>
   <li>Upgraded dependencies to fix the following vulnerabilities: CVE-2015-6420. (Thanks to @kinow)</li>
   <li>Fixed incorrect computation of post-rotation bounding boxes, manifesting as bogus values passed to the <code>resulting_size</code> delegate method arguments. (Thanks to @SaschaAdler)</li>
-  <li>Fixed potentially incorrect tile sizes being returned in information responses when using OpenJpegProcessor.</li>
+  <li>Fixed a bug in FilesystemCache when multiple processes tried to create the same directory at the same time. (Thanks to @cbeer)</li>
+  <li>Fixed potentially incorrect tile sizes in information responses when using OpenJpegProcessor.</li>
   <li>Fixed a resource leak when using image overlays.</li>
   <li>Fixed potential malformed links in the Control Panel.</li>
   <li>Improvements in the testing and build process. (Thanks to @kinow)</li>

--- a/website/changes.html
+++ b/website/changes.html
@@ -63,6 +63,7 @@ title: Change Log
 
 <ul>
   <li>Upgraded dependencies to fix the following vulnerabilities: CVE-2015-6420. (Thanks to @kinow)</li>
+  <li>Fixed incorrect computation of post-rotation bounding boxes, manifesting as bogus values passed to the <code>resulting_size</code> delegate method arguments. (Thanks to @SaschaAdler)</li>
   <li>Fixed potentially incorrect tile sizes being returned in information responses when using OpenJpegProcessor.</li>
   <li>Fixed a resource leak when using image overlays.</li>
   <li>Fixed potential malformed links in the Control Panel.</li>

--- a/website/changes.html
+++ b/website/changes.html
@@ -12,6 +12,8 @@ title: Change Log
     <ul>
       <li>HTTP/2 is supported in standalone mode. (See the "Getting Started" section of the user manual.)</li>
       <li>The accept queue limit of the standalone HTTP &amp; HTTPS servers is configurable.</li>
+      <li>The minimum size in IIIF Image API 2.x <code>info.json</code> responses is configurable. (Thanks to @cbeer)</li>
+      <li>The maximum size in IIIF Image API 2.x <code>info.json</code> responses is the full image size, rather than half size. (Thanks to @cbeer)</li>
       <li>Image requests may include a <code>?response-content-disposition</code> query argument to suggest a response <code>Content-Disposition</code>.</li>
       <li>Added a REST API method for purging the delegate method invocation cache.</li>
       <li>Added a "Warnings" section in the "Processors" section of the Control Panel.</li>

--- a/website/upgrade.html
+++ b/website/upgrade.html
@@ -15,6 +15,7 @@ title: Upgrading
       <li><code>http.http2.enabled</code></li>
       <li><code>https.http2.enabled</code></li>
       <li><code>http.accept_queue_limit</code></li>
+      <li><code>endpoint.iiif.min_size</code></li>
       <li><code>HttpResolver.trust_invalid_certs</code></li>
       <li><code>processor.psd</code></li>
       <li><code>processor.sgi</code></li>


### PR DESCRIPTION
This PR does two things, and I'm happy if you want to take one, both, or neither.

- Makes the IIIF minimum image size configurable (was hardcoded at 64px; we'd like to raise that locally)
- Adds the full size image to the list of `sizes` (I can get into our rationale, but, basically, we want our level 0-compatible clients to also have access to the full size image without needing to make inferences based on the profile/width/height/maxwidth/maxheight properties) 