### PR TITLE
Guard against cache directory creation race conditions

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/cache/FilesystemCache.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/cache/FilesystemCache.java
@@ -933,7 +933,8 @@ class FilesystemCache implements SourceCache, DerivativeCache {
 
         try {
             if (!tempFile.getParentFile().exists() &&
-                    !tempFile.getParentFile().mkdirs()) {
+                    !tempFile.getParentFile().mkdirs() &&
+                    !tempFile.getParentFile().exists()) {
                 throw new IOException("Unable to create directory: " +
                         tempFile.getParentFile());
             }


### PR DESCRIPTION
I believe we're seeing a race condition in the FilesystemCache when we try to use a shared cache across multiple Cantaloupe servers. I believe a patch like this might address the problem?