### PR TITLE
Ensure that the source cache is also purged, and refactor a bit.

### DIFF
--- a/src/test/java/edu/illinois/library/cantaloupe/cache/FilesystemCacheTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/cache/FilesystemCacheTest.java
@@ -565,7 +565,7 @@ public class FilesystemCacheTest extends BaseTest {
         imageFile.createNewFile();
 
         instance.purgeExpired();
-        assertEquals(1, FileUtils.listFiles(sourceImagePath, null, true).size());
+        assertEquals(0, FileUtils.listFiles(sourceImagePath, null, true).size());
         assertEquals(1, FileUtils.listFiles(derivativeImagePath, null, true).size());
         assertEquals(0, FileUtils.listFiles(infoPath, null, true).size());
     }


### PR DESCRIPTION
This patch fixes #180. Note that I took the opportunity to re-factor the code a bit as well, rather than just copy the block, since it was a third instance of the cleaner.

FWIW, we ran this today in production with a cache that had over 12 GB in the source cache, a TTL of 3600 seconds and cleaner running every 1800 seconds.
