### PR TITLE
Add support for storage URI and SAS Token directly in URL.

### DIFF
--- a/cantaloupe.properties.sample
+++ b/cantaloupe.properties.sample
@@ -198,12 +198,15 @@ AmazonS3Resolver.lookup_strategy = BasicLookupStrategy
 #----------------------------------------
 
 # !! Name of your Azure account.
+# !! Leave blank if using URI with a SAS token in your object key.
 AzureStorageResolver.account_name =
 
 # !! Key of your Azure account.
+# !! Leave blank if using URI with a SAS token in your object key.
 AzureStorageResolver.account_key =
 
 # !! Name of the container containing images to be served.
+# !! Leave blank if using URI with the container in your object key.
 AzureStorageResolver.container_name =
 
 # Tells AzureStorageResolver how to look up objects. Allowed values are

--- a/src/test/java/edu/illinois/library/cantaloupe/resolver/AzureStorageResolverTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/resolver/AzureStorageResolverTest.java
@@ -73,6 +73,7 @@ public class AzureStorageResolverTest extends BaseTest {
         return client;
     }
 
+
     private static String getAccountName() {
         org.apache.commons.configuration.Configuration testConfig =
                 TestUtil.getTestConfig();

--- a/test.properties.sample
+++ b/test.properties.sample
@@ -11,6 +11,7 @@ amazons3.secret_key =
 amazons3.bucket =
 
 # Used by AzureStorageResolverTest and AzureStorageCacheTest.
+# Note: leave blank to test sas and container specified in a URL to the object key.
 azurestorage.account_name =
 azurestorage.account_key =
 azurestorage.container =


### PR DESCRIPTION
Would like to have this considered to add support to the Azure resolver to directly connect to blob store to get images using Storage URI path and Sas tokens:
https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#resource-uri-syntax
https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1#how-a-shared-access-signature-works