### PR TITLE
Fix Switch Statement Fallthrough with Azure Storage Delegate

### DIFF
--- a/src/main/java/edu/illinois/library/cantaloupe/source/AzureStorageSource.java
+++ b/src/main/java/edu/illinois/library/cantaloupe/source/AzureStorageSource.java
@@ -10,7 +10,6 @@ import edu.illinois.library.cantaloupe.config.Configuration;
 import edu.illinois.library.cantaloupe.config.Key;
 import edu.illinois.library.cantaloupe.image.Format;
 import edu.illinois.library.cantaloupe.image.MediaType;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -174,7 +173,7 @@ class AzureStorageSource extends AbstractSource implements StreamSource {
         return cachedBlob;
     }
 
-    private String getObjectKey() throws IOException {
+    public String getObjectKey() throws IOException {
         if (objectKey == null) {
             final LookupStrategy strategy =
                     LookupStrategy.from(Key.AZURESTORAGESOURCE_LOOKUP_STRATEGY);
@@ -186,8 +185,10 @@ class AzureStorageSource extends AbstractSource implements StreamSource {
                         LOGGER.error(e.getMessage(), e);
                         throw new IOException(e);
                     }
+                    break;
                 default:
                     objectKey = identifier.toString();
+                    break;
             }
         }
         return objectKey;

--- a/src/test/java/edu/illinois/library/cantaloupe/source/AzureStorageSourceTest.java
+++ b/src/test/java/edu/illinois/library/cantaloupe/source/AzureStorageSourceTest.java
@@ -355,4 +355,22 @@ public class AzureStorageSourceTest extends AbstractSourceTest {
         instance.newStreamFactory();
     }
 
+    /* getObjectKey() */
+    @Test
+    public void testGetObjectKey() throws Exception {
+        assertNotNull(instance.getObjectKey());
+    }
+
+    @Test
+    public void testGetObjectKeyBasicLookupStrategy() throws Exception {
+        String result = instance.getObjectKey();
+        assertEquals(OBJECT_KEY_WITH_CONTENT_TYPE_AND_RECOGNIZED_EXTENSION, result);
+    }
+
+    @Test
+    public void testGetObjectKeyDelegateLookupStrategy() throws Exception {
+        useScriptLookupStrategy();
+        String result = instance.getObjectKey();
+        assertEquals(OBJECT_KEY_WITH_CONTENT_TYPE_BUT_NO_EXTENSION, result);
+    }
 }

--- a/src/test/resources/delegates.rb
+++ b/src/test/resources/delegates.rb
@@ -66,7 +66,14 @@ class CustomDelegate
   end
 
   def azurestoragesource_blob_key(options = {})
-    context['identifier'] != 'missing' ? context['identifier'] : nil
+    case context['identifier']
+      when 'missing'
+        return nil
+      when 'jpeg.jpg'
+        return 'jpg'
+      else
+        return context['identifier']
+    end
   end
 
   def filesystemsource_pathname(options = {})


### PR DESCRIPTION
Allows the setting of the AzureStorageSource objectKey with a delegate script